### PR TITLE
aplay: fix description about options for process duration

### DIFF
--- a/aplay/aplay.1
+++ b/aplay/aplay.1
@@ -75,12 +75,14 @@ Valid values are 2000 through 192000 Hertz.
 \fI\-d, \-\-duration=#\fP
 Interrupt after # seconds.
 A value of zero means infinity.
-The default is zero, so if this option is omitted then the arecord process will run until it is killed.
+The default is zero, so if this option is omitted then the record/playback process will run until it is killed.
+Either '-d' or '-s' option is available exclusively.
 .TP
 \fI\-s, \-\-samples=#\fP
 Interrupt after tranmission of # PCM frames.
 A value of zero means infinity.
 The default is zero, so if this options is omitted then the record/playback process will run until it is killed.
+Either '-d' or '-s' option is available exclusively.
 .TP
 \fI\-M, \-\-mmap\fP            
 Use memory\-mapped (mmap) I/O mode for the audio stream.

--- a/aplay/aplay.1
+++ b/aplay/aplay.1
@@ -77,9 +77,6 @@ Interrupt after # seconds.
 A value of zero means infinity.
 The default is zero, so if this option is omitted then the arecord process will run until it is killed.
 .TP
-\fI\-s, \-\-sleep\-min=#\fP
-Min ticks to sleep. The default is not to sleep.
-.TP
 \fI\-M, \-\-mmap\fP            
 Use memory\-mapped (mmap) I/O mode for the audio stream.
 If this option is not set, the read/write I/O mode will be used.

--- a/aplay/aplay.1
+++ b/aplay/aplay.1
@@ -77,6 +77,11 @@ Interrupt after # seconds.
 A value of zero means infinity.
 The default is zero, so if this option is omitted then the arecord process will run until it is killed.
 .TP
+\fI\-s, \-\-samples=#\fP
+Interrupt after tranmission of # PCM frames.
+A value of zero means infinity.
+The default is zero, so if this options is omitted then the record/playback process will run until it is killed.
+.TP
 \fI\-M, \-\-mmap\fP            
 Use memory\-mapped (mmap) I/O mode for the audio stream.
 If this option is not set, the read/write I/O mode will be used.


### PR DESCRIPTION
Hi,

At present, aplay has two options for duration to process PCM frames.
However, the recent one ('--samples') option is not described yet in
its manual. Furthermore, '-s' option was used for '--sleep-min' option
once and description for this option was left as is. This can puzzle
uses.

This patchset improves description about options for process duration.