### PR TITLE
alsa-utils: axfer: use second argument for transmission direction

### DIFF
--- a/axfer/main.c
+++ b/axfer/main.c
@@ -251,8 +251,14 @@ int main(int argc, char *const *argv)
 		// The second option should be either 'capture' or 'direction'
 		// if subcommand is neither 'version' nor 'help'.
 		if (subcmd != SUBCMD_VERSION && subcmd != SUBCMD_HELP) {
-			if (!detect_direction(argc, argv, &direction))
+			if (!detect_direction(argc, argv, &direction)) {
 				subcmd = SUBCMD_HELP;
+			} else {
+				// argv[0] is needed for unparsed option to use
+				// getopt_long(3).
+				argc -= 2;
+				argv += 2;
+			}
 		}
 	}
 

--- a/axfer/subcmd-list.c
+++ b/axfer/subcmd-list.c
@@ -233,11 +233,11 @@ static int detect_operation(int argc, char *const *argv, enum list_op *op)
 	};
 	int i;
 
-	if (strcmp(argv[1], "list") || argc < 3)
+	if (argc < 2)
 		return false;
 
 	for (i = 0; i < ARRAY_SIZE(ops); ++i) {
-		if (!strcmp(argv[2], ops[i])) {
+		if (!strcmp(argv[1], ops[i])) {
 			*op = i;
 			return true;
 		}
@@ -252,11 +252,9 @@ int subcmd_list(int argc, char *const *argv, snd_pcm_stream_t direction)
 	int err = 0;
 
 	// Renewed command system.
-	if (argc > 1) {
-		if (!detect_operation(argc, argv, &op) &&
-		    !decide_operation(argc, argv, &op))
-				err = -EINVAL;
-	}
+	if (!detect_operation(argc, argv, &op) &&
+	    !decide_operation(argc, argv, &op))
+			err = -EINVAL;
 
 	if (op == LIST_OP_DEVICE)
 		err = list_devices(direction);

--- a/axfer/subcmd-list.c
+++ b/axfer/subcmd-list.c
@@ -225,30 +225,37 @@ static bool decide_operation(int argc, char *const *argv, enum list_op *op)
 	return false;
 }
 
-int subcmd_list(int argc, char *const *argv, snd_pcm_stream_t direction)
+static int detect_operation(int argc, char *const *argv, enum list_op *op)
 {
-	static const struct {
-		const char *const category;
-		int (*func)(snd_pcm_stream_t direction);
-	} ops[] = {
-		{"device",	list_devices},
-		{"pcm",		list_pcms},
+	static const char *const ops[] = {
+		[LIST_OP_DEVICE] = "device",
+		[LIST_OP_PCM] = "pcm",
 	};
-	enum list_op op;
 	int i;
-	int err;
 
-	// Renewed command system.
-	if (argc > 2 && !strcmp(argv[1], "list")) {
-		for (i = 0; i < ARRAY_SIZE(ops); ++i) {
-			if (!strcmp(ops[i].category, argv[2]))
-				return ops[i].func(direction);
+	if (strcmp(argv[1], "list") || argc < 3)
+		return false;
+
+	for (i = 0; i < ARRAY_SIZE(ops); ++i) {
+		if (!strcmp(argv[2], ops[i])) {
+			*op = i;
+			return true;
 		}
 	}
 
-	if (!decide_operation(argc, argv, &op)) {
-		err = -EINVAL;
-		op = LIST_OP_HELP;
+	return false;
+}
+
+int subcmd_list(int argc, char *const *argv, snd_pcm_stream_t direction)
+{
+	enum list_op op = LIST_OP_HELP;
+	int err = 0;
+
+	// Renewed command system.
+	if (argc > 1) {
+		if (!detect_operation(argc, argv, &op) &&
+		    !decide_operation(argc, argv, &op))
+				err = -EINVAL;
 	}
 
 	if (op == LIST_OP_DEVICE)

--- a/axfer/subcmd-transfer.c
+++ b/axfer/subcmd-transfer.c
@@ -435,13 +435,6 @@ int subcmd_transfer(int argc, char *const *argv, snd_pcm_stream_t direction)
 	uint64_t actual_frame_count = 0;
 	int err = 0;
 
-	// Renewed command system.
-	if (argc > 2 && !strcmp(argv[1], "transfer")) {
-		// Go ahead to parse file paths properly.
-		--argc;
-		++argv;
-	}
-
 	err = prepare_signal_handler(&ctx);
 	if (err < 0)
 		return err;


### PR DESCRIPTION
This patchset is for axfer command in alsa-utils to use second argument 
for transmission direction. As a result, syntax of its command line is

  axfer subcommand direction options

For example:
$ axfer transfer playback [options]
$ axfer list capture [options]

This fashion requires more typing to users, however in my taste this
looks good because it's easier to understand than long/short options. 

Additionally, this patchset applies refactoring to list subcommand.

Takashi Sakamoto (5):
  axfer: apply refactoring to list subcommand for backward compatibility
    to aplay(1)
  axfer: apply refactoring in list subcommand for new command system
  axfer: use second argument in command line for transmission direction
  axfer: use transfer subcommand as a default for compatibility mode to
    aplay(1)
  axfer: truncate parsed arguments before operating subcommand

```
 axfer/main.c            | 100 +++++++++++++++++++++++++++++-----------
 axfer/subcmd-list.c     |  85 +++++++++++++++++++++++-----------
 axfer/subcmd-transfer.c |   7 ---
 3 files changed, 133 insertions(+), 59 deletions(-)
```