### PR TITLE
axfer: check whether a terminal is referred for stdio

### DIFF
--- a/axfer/container.c
+++ b/axfer/container.c
@@ -168,6 +168,13 @@ int container_parser_init(struct container_context *cntr,
 	// Open a target descriptor.
 	if (!strcmp(path, "-")) {
 		cntr->fd = fileno(stdin);
+		if (isatty(cntr->fd)) {
+			fprintf(stderr,
+				"A terminal is referred for standard input. "
+				"Output from any process or shell redirection "
+				"should be referred instead.\n");
+			return -EIO;
+		}
 		err = set_nonblock_flag(cntr->fd);
 		if (err < 0)
 			return err;
@@ -245,6 +252,13 @@ int container_builder_init(struct container_context *cntr,
 		return -EINVAL;
 	if (!strcmp(path, "-")) {
 		cntr->fd = fileno(stdout);
+		if (isatty(cntr->fd)) {
+			fprintf(stderr,
+				"A terminal is referred for standard output. "
+				"Input to any process or shell redirection "
+				"should be referred instead.\n");
+			return -EIO;
+		}
 		err = set_nonblock_flag(cntr->fd);
 		if (err < 0)
 			return err;


### PR DESCRIPTION
A reference to a terminal for standard input/output brings some
troubles. For capture transmission, it can bring some terminal
control codes and it's possible to make the terminal in disorder.
For playback transmission, it can bring endless loop to read
data for detection of type of container.

This commit checks whether a terminal is referred for the standard
input/output by a call isatty(3). When detecting a terminal,
axfer run time prints message and goes to finish.

Suggested-by: Takashi Iwai <tiwai@suse.com>
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>