### PR TITLE
[PATCH 0/4] alsa-utils: axfer: add help texts

### DIFF
--- a/axfer/main.c
+++ b/axfer/main.c
@@ -67,7 +67,17 @@ static void print_version(const char *const cmdname)
 
 static void print_help(void)
 {
-	printf("help\n");
+	printf(
+"Usage:\n"
+"  axfer transfer DIRECTION OPTIONS\n"
+"  axfer list DIRECTION OPTIONS\n"
+"  axfer version\n"
+"  axfer help\n"
+"\n"
+"  where:\n"
+"    DIRECTION = capture | playback\n"
+"    OPTIONS = -h | --help | (subcommand specific)\n"
+	);
 }
 
 // Backward compatibility to aplay(1).

--- a/axfer/subcmd-list.c
+++ b/axfer/subcmd-list.c
@@ -193,7 +193,14 @@ static int list_pcms(snd_pcm_stream_t direction)
 
 static void print_help(void)
 {
-	printf("help for list sub-command.\n");
+	printf(
+"Usage:\n"
+"  axfer list DIRECTION TARGET\n"
+"\n"
+"  where:\n"
+"    DIRECTION = capture | playback\n"
+"    TARGET = device | pcm\n"
+	);
 }
 
 // Backward compatibility to aplay(1).

--- a/axfer/xfer-libasound.c
+++ b/axfer/xfer-libasound.c
@@ -880,6 +880,11 @@ static void xfer_libasound_destroy(struct xfer_context *xfer)
 	state->log = NULL;
 }
 
+static void xfer_libasound_help(struct xfer_context *xfer)
+{
+	printf("      (placeholder)\n");
+}
+
 const struct xfer_data xfer_libasound = {
 	.s_opts = S_OPTS,
 	.l_opts = l_opts,
@@ -893,6 +898,7 @@ const struct xfer_data xfer_libasound = {
 		.pause		= xfer_libasound_pause,
 		.post_process	= xfer_libasound_post_process,
 		.destroy	= xfer_libasound_destroy,
+		.help		= xfer_libasound_help,
 	},
 	.private_size = sizeof(struct libasound_state),
 };

--- a/axfer/xfer-libffado.c
+++ b/axfer/xfer-libffado.c
@@ -537,6 +537,11 @@ static void xfer_libffado_destroy(struct xfer_context *xfer)
 	state->guid_literal = NULL;
 }
 
+static void xfer_libffado_help(struct xfer_context *xfer)
+{
+	printf("      (placeholder)\n");
+}
+
 const struct xfer_data xfer_libffado = {
 	.s_opts = S_OPTS,
 	.l_opts = l_opts,
@@ -550,6 +555,7 @@ const struct xfer_data xfer_libffado = {
 		.pause		= xfer_libffado_pause,
 		.post_process	= xfer_libffado_post_process,
 		.destroy	= xfer_libffado_destroy,
+		.help		= xfer_libffado_help,
 	},
 	.private_size = sizeof(struct libffado_state),
 };

--- a/axfer/xfer-options.c
+++ b/axfer/xfer-options.c
@@ -373,6 +373,12 @@ int xfer_options_parse_args(struct xfer_context *xfer,
 
 	if (xfer->help) {
 		print_help();
+		if (xfer->ops->help) {
+			printf("\n");
+			printf("    BACKEND-OPTIONS (%s) =\n",
+			       xfer_label_from_type(xfer->type));
+			xfer->ops->help(xfer);
+		}
 		return 0;
 	}
 

--- a/axfer/xfer-options.c
+++ b/axfer/xfer-options.c
@@ -25,6 +25,30 @@ enum no_short_opts {
 	OPT_PROCESS_ID_FILE,
 };
 
+static int print_help()
+{
+	printf(
+"Usage:\n"
+"  axfer transfer DIRECTION [ COMMON-OPTIONS ] [ BACKEND-OPTIONS ]\n"
+"\n"
+"  where:\n"
+"    DIRECTION = capture | playback\n"
+"    COMMON-OPTIONS =\n"
+"      -h, --help              help\n"
+"      -v, --verbose           verbose\n"
+"      -q, --quiet             quiet mode\n"
+"      -d, --duration=#        interrupt after # seconds\n"
+"      -s, --samples=#         interrupt after # frames\n"
+"      -f, --format=FORMAT     sample format (case-insensitive)\n"
+"      -c, --channels=#        channels\n"
+"      -r, --rate=#            numeric sample rate in unit of Hz or kHz\n"
+"      -t, --file-type=TYPE    file type (wav, au, sparc, voc or raw, case-insentive)\n"
+"      -I, --separate-channels one file for each channel\n"
+"      --dump-hw-params        dump hw_params of the device\n"
+"      --xfer-type=BACKEND     backend type (libasound, libffado)\n"
+	);
+}
+
 static int allocate_paths(struct xfer_context *xfer, char *const *paths,
 			   unsigned int count)
 {
@@ -346,6 +370,11 @@ int xfer_options_parse_args(struct xfer_context *xfer,
 
 	free(l_opts);
 	free(s_opts);
+
+	if (xfer->help) {
+		print_help();
+		return 0;
+	}
 
 	err = allocate_paths(xfer, argv + optind, argc - optind);
 	if (err < 0)

--- a/axfer/xfer.c
+++ b/axfer/xfer.c
@@ -30,6 +30,11 @@ enum xfer_type xfer_type_from_label(const char *label)
 	return XFER_TYPE_UNSUPPORTED;
 }
 
+const char *xfer_label_from_type(enum xfer_type type)
+{
+	return xfer_type_labels[type];
+}
+
 int xfer_context_init(struct xfer_context *xfer, enum xfer_type type,
 		      snd_pcm_stream_t direction, int argc, char *const *argv)
 {

--- a/axfer/xfer.h
+++ b/axfer/xfer.h
@@ -53,6 +53,7 @@ struct xfer_context {
 };
 
 enum xfer_type xfer_type_from_label(const char *label);
+const char *xfer_label_from_type(enum xfer_type type);
 
 int xfer_context_init(struct xfer_context *xfer, enum xfer_type type,
 		      snd_pcm_stream_t direction, int argc, char *const *argv);
@@ -96,6 +97,7 @@ struct xfer_ops {
 	void (*post_process)(struct xfer_context *xfer);
 	void (*destroy)(struct xfer_context *xfer);
 	void (*pause)(struct xfer_context *xfer, bool enable);
+	void (*help)(struct xfer_context *xfer);
 };
 
 struct xfer_data {


### PR DESCRIPTION
This patchset adds help texts for command entry, list and transfer
subcommands. In this time, contents for each backend of transfer
subcommand is not added yet.

Unfortunately, execution of aliases (arecord/aplay) can print help text
for command text only. This bug will be fixed in future commits.

Additionally, due to program design, execution of the aliases cannot
print help text of list subcommand. This is unavoidable loss of backward
compatibility.

```
Takashi Sakamoto (4):
  axfer: print help text of command entry
  axfer: print help text of list subcommand
  axfer: print help text of transfer subcommand just for common options
  axfer: enable each backend to print own help

 axfer/main.c           | 12 +++++++++++-
 axfer/subcmd-list.c    |  9 ++++++++-
 axfer/xfer-libasound.c |  6 ++++++
 axfer/xfer-libffado.c  |  6 ++++++
 axfer/xfer-options.c   | 35 +++++++++++++++++++++++++++++++++++
 axfer/xfer.c           |  5 +++++
 axfer/xfer.h           |  2 ++
 7 files changed, 73 insertions(+), 2 deletions(-)
```