### PR TITLE
[PATCH] alsa-utils: axfer: add missing header file of unit test to distribution

### DIFF
--- a/axfer/test/Makefile.am
+++ b/axfer/test/Makefile.am
@@ -14,6 +14,7 @@ container_test_SOURCES = \
 	../container-voc.c \
 	../container-raw.c \
 	generator.c \
+	generator.h \
 	container-test.c
 
 mapper_test_SOURCES = \
@@ -28,4 +29,5 @@ mapper_test_SOURCES = \
 	../mapper-single.c \
 	../mapper-multiple.c \
 	generator.c \
+	generator.h \
 	mapper-test.c


### PR DESCRIPTION
The file 'axfer/test/generator.h' is missing in distribution and brings
FTBFS for unit tests of axfer.

This commit fixes to add it.

Reported-by: Elimar Riesebieter <riesebie@lxtec.de>
Fixes: b878df1ff0b0: ('axfer: add unit test for container interface')
Fixes: 39d1ab8a0cb4: ('axfer: add a unit test for mapper interface')