### PR TITLE
[PATCH] axfer: allow to be compiled with glibc-2.11 or former

### DIFF
--- a/axfer/waiter-select.c
+++ b/axfer/waiter-select.c
@@ -15,9 +15,18 @@
 #include <sys/select.h>
 
 // Except for POLLERR.
-#define POLLIN_SET	(POLLRDNORM | POLLRDBAND | POLLIN | POLLHUP)
-#define POLLOUT_SET	(POLLWRBAND | POLLWRNORM | POLLOUT)
+#ifdef POLLRDNORM
+// This program is for userspace compliant to POSIX 2008 (IEEE 1003.1:2008).
+// This is the default compliance level since glibc-2.12 or later.
+# define POLLIN_SET	(POLLRDNORM | POLLRDBAND | POLLIN | POLLHUP)
+# define POLLOUT_SET	(POLLWRBAND | POLLWRNORM | POLLOUT)
+#else
+// However it's allowed to be for old compliance levels.
+# define POLLIN_SET	(POLLIN | POLLHUP)
+# define POLLOUT_SET	(POLLOUT)
+#endif
 #define POLLEX_SET	(POLLPRI)
+
 
 struct select_state {
 	fd_set rfds_rd;


### PR DESCRIPTION
The program, axfer, was developed in userspace with glibc-2.28. This
userspace is mostly compliant to POSIX:2008 and some additional macros
for poll event are officially available. The glibc supports them as a
default since its v2.12 release. It will be failed to be compiled with
old glibc or the other libraries for C standard APIs.

One of the purpose of axfer is an better alternative of aplay. In a
point of the purpose, it's preferable to be compiled with the old
libraries.

This commit adds conditional macros to be compiled with libraries for
old compliance level of POSIX. This fixes #9 .