### PR TITLE
axfer: Declare global variables as 'extern' in header

### DIFF
--- a/axfer/container.h
+++ b/axfer/container.h
@@ -120,7 +120,7 @@ extern const struct container_builder container_builder_au;
 extern const struct container_parser container_parser_voc;
 extern const struct container_builder container_builder_voc;
 
-const struct container_parser container_parser_raw;
-const struct container_builder container_builder_raw;
+extern const struct container_parser container_parser_raw;
+extern const struct container_builder container_builder_raw;
 
 #endif


### PR DESCRIPTION
This avoids multiple definitions of the same global variable (one in
each file that includes this header), and fixes a linking error when
compiled with -fno-common.

Signed-off-by: Samuel Holland <samuel@sholland.org>