### PR TITLE
axfer: Fix creation of v1.2 headers on big-endian systems

### DIFF
--- a/axfer/container-voc.c
+++ b/axfer/container-voc.c
@@ -622,8 +622,8 @@ static int write_v120_format_block(struct container_context *cntr,
 	build_block_data_size(block->size, 12 + byte_count);
 
 	block->frames_per_second = htole32(frames_per_second);
-	block->bits_per_sample = htole16(state->bytes_per_sample * 8);
-	block->samples_per_frame = htole16(state->samples_per_frame);
+	block->bits_per_sample = state->bytes_per_sample * 8;
+	block->samples_per_frame = state->samples_per_frame;
 	block->code_id = htole16(state->code_id);
 
 	return container_recursive_write(cntr, block, sizeof(*block));


### PR DESCRIPTION
struct block_v120_format defines these members as uint8_t. On
little-endian systems, no swapping is done, and the generated block
header is fine. However, on big-endian machines, the value is swapped to
the high byte and then truncated by the assignment, causing both
bits_per_sample and samples_per_frame to be zero.

This fixes an assertion failure in container-test when later
parsing the header ["assert(*samples_per_frame > 0);" in
container_context_pre_process()].

Signed-off-by: Samuel Holland <samuel@sholland.org>