### PR TITLE
alsa-utils: axfer/test: fix compiler warnings due to uninitialized return value

### DIFF
--- a/axfer/test/mapper-test.c
+++ b/axfer/test/mapper-test.c
@@ -300,8 +300,10 @@ static int test_vector(struct mapper_trial *trial, snd_pcm_access_t access,
 
 	for (i = 0; i < cntr_count; ++i) {
 		bufs[i] = malloc(size);
-		if (bufs[i] == NULL)
+		if (bufs[i] == NULL) {
+			err = -ENOMEM;
 			goto end;
+		}
 		memset(bufs[i], 0, size);
 	}
 

--- a/axfer/test/mapper-test.c
+++ b/axfer/test/mapper-test.c
@@ -71,7 +71,7 @@ static int test_demux(struct mapper_trial *trial, snd_pcm_access_t access,
 	unsigned int bytes_per_sample;
 	uint64_t total_frame_count;
 	int i;
-	int err;
+	int err = 0;
 
 	for (i = 0; i < cntr_count; ++i) {
 		snd_pcm_format_t format;
@@ -163,7 +163,7 @@ static int test_mux(struct mapper_trial *trial, snd_pcm_access_t access,
 	unsigned int bytes_per_sample;
 	uint64_t total_frame_count;
 	int i;
-	int err;
+	int err = 0;
 
 	for (i = 0; i < cntr_count; ++i) {
 		snd_pcm_format_t format;


### PR DESCRIPTION
Hi,

One of test programs for axfer internals has bugs to let compiler generate warnings due to uninitialized return value. This patchset fixes them.

```
Takashi Sakamoto (2):
  axfer/test: fix uninitialized warning
  axfer/test: fix uninitialized warning

 axfer/test/mapper-test.c | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```