### PR TITLE
axfer: mapper: fix parameter check for demuxer

### DIFF
--- a/axfer/mapper-multiple.c
+++ b/axfer/mapper-multiple.c
@@ -114,7 +114,8 @@ static int multiple_pre_process(struct mapper_context *mapper,
 		// configured to store one sample per frame.
 		if (mapper->type == MAPPER_TYPE_DEMUXER) {
 			for (i = 0; i < cntr_count; ++i) {
-				if (cntrs->samples_per_frame != 1)
+				cntr = cntrs + i;
+				if (cntr->samples_per_frame != 1)
 					return -EINVAL;
 			}
 		}


### PR DESCRIPTION
Each container should be configured to store one saple per frame in
demuxer case. This commit fixes the bug.

Fixes: 25c8e3bebb53 ('axfer: add support for a mapper for multiple target')
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>