### PR TITLE
alsactl/init_sysfs: use /sys/kernel/uevent_seqnum as sys filesystem c…

### DIFF
--- a/alsactl/init_sysfs.c
+++ b/alsactl/init_sysfs.c
@@ -43,7 +43,7 @@ static int sysfs_init(void)
 	dbg("sysfs_path='%s'", sysfs_path);
 
 	strlcpy(sysfs_test, sysfs_path, sizeof(sysfs_test));
-	strlcat(sysfs_test, "/kernel/uevent_helper", sizeof(sysfs_test));
+	strlcat(sysfs_test, "/kernel/uevent_seqnum", sizeof(sysfs_test));
 	if (access(sysfs_test, F_OK)) {
 		error("sysfs path '%s' is invalid\n", sysfs_path);
 		return -errno;


### PR DESCRIPTION
…heck

Use /sys/kernel/uevent_seqnum instead of /sys/kernel/uevent_helper,
fixes the following warning for linux kernels with UEVENT_HELPER
disabled:

  /usr/sbin/alsactl: sysfs_init:48: sysfs path '/sys' is invalid

Signed-off-by: Peter Seiderer <ps.report@gmx.net>