### PR TITLE
axfer: break transmission of audio data frame when transmission backend queues no PCM event within timeout

### DIFF
--- a/axfer/waiter-select.c
+++ b/axfer/waiter-select.c
@@ -91,7 +91,7 @@ static int select_wait_event(struct waiter_context *waiter, int timeout_msec)
 			pfd->revents |= POLLHUP;
 	}
 
-	return 0;
+	return err;
 }
 
 static void select_release(struct waiter_context *waiter)

--- a/axfer/waiter-select.c
+++ b/axfer/waiter-select.c
@@ -77,7 +77,7 @@ static int select_wait_event(struct waiter_context *waiter, int timeout_msec)
 	err = select(fd_max + 1, &state->rfds_rd, &state->rfds_wr,
 		     &state->rfds_ex, tv_ptr);
 	if (err < 0)
-		return err;
+		return -errno;
 
 	for (i = 0; i < waiter->pfd_count; ++i) {
 		pfd = &waiter->pfds[i];

--- a/axfer/xfer-libasound-irq-mmap.c
+++ b/axfer/xfer-libasound-irq-mmap.c
@@ -82,10 +82,28 @@ static int irq_mmap_process_frames(struct libasound_state *state,
 	int err;
 
 	if (state->use_waiter) {
+		unsigned int msec_per_buffer;
 		unsigned short revents;
 
+		// Wait during msec equivalent to all audio data frames in
+		// buffer instead of period, for safe.
+		err = snd_pcm_hw_params_get_buffer_time(state->hw_params,
+							&msec_per_buffer, NULL);
+		if (err < 0)
+			return err;
+		msec_per_buffer /= 1000;
+
 		// Wait for hardware IRQ when no avail space in buffer.
-		err = xfer_libasound_wait_event(state, -1, &revents);
+		err = xfer_libasound_wait_event(state, msec_per_buffer,
+						&revents);
+		if (err == -ETIMEDOUT) {
+			logging(state,
+				"No event occurs for PCM substream during %u "
+				"msec. The implementaion of kernel driver or "
+				"userland backend causes this issue.\n",
+				msec_per_buffer);
+			return err;
+		}
 		if (err < 0)
 			return err;
 		if (revents & POLLERR) {

--- a/axfer/xfer-libasound-irq-rw.c
+++ b/axfer/xfer-libasound-irq-rw.c
@@ -21,12 +21,21 @@ struct rw_closure {
 
 static int wait_for_avail(struct libasound_state *state)
 {
+	unsigned int msec_per_buffer;
 	unsigned short revents;
 	unsigned short event;
 	int err;
 
+	// Wait during msec equivalent to all audio data frames in buffer
+	// instead of period, for safe.
+	err = snd_pcm_hw_params_get_buffer_time(state->hw_params,
+						&msec_per_buffer, NULL);
+	if (err < 0)
+		return err;
+	msec_per_buffer /= 1000;
+
 	// Wait for hardware IRQ when no available space.
-	err = xfer_libasound_wait_event(state, -1, &revents);
+	err = xfer_libasound_wait_event(state, msec_per_buffer, &revents);
 	if (err < 0)
 		return err;
 


### PR DESCRIPTION
Axfer internally has the waiter abstraction for polling system call. This is used without explicit timeout for IRQ-based scheduling model. As a result, axfer process is corrupted to be blocked due to a call of polling system call when transmission backend has a bug to queue PCM event in I/O thread or hardware IRQ context.

This patchset implements error reporting for such buggy backend. When call of polling system call returns with timeout, axfer reports it as a bug. The timeout is equivalent to the size of buffer. Precisely it should be the size of period, however the larger size is used to stabilize runtime for existent PCM plugins.

```
Takashi Sakamoto (6):
  axfer: return the number of file descriptors for I/O events from select(2) waiter
  axfer: fix to return error code when a call of select(2) fails
  axfer: return ETIMEDOUT when no event occurs after waiter expiration
  axfer: handle -ETIMEDOUT before handle mmap I/O operation
  axfer: code refactoring for a helper function to wait for avail buffer space
  axfer: handle -ETIMEDOUT before non-block I/O operation

 axfer/waiter-select.c           |  4 +--
 axfer/xfer-libasound-irq-mmap.c | 19 +++++++++-
 axfer/xfer-libasound-irq-rw.c   | 62 +++++++++++++++++++--------------
 axfer/xfer-libasound.c          | 21 +++++++----
 4 files changed, 70 insertions(+), 36 deletions(-)
```