### PR TITLE
alsactl: Wrong line if (!sched_setscheduler(0, SCHED_IDLE, &sched_param))

### DIFF
--- a/alsactl/alsactl.c
+++ b/alsactl/alsactl.c
@@ -161,7 +161,7 @@ static void do_nice(int use_nice, int sched_idle)
 	if (sched_idle) {
 		if (sched_getparam(0, &sched_param) >= 0) {
 			sched_param.sched_priority = 0;
-			if (sched_setscheduler(0, SCHED_IDLE, &sched_param))
+			if (sched_setscheduler(0, SCHED_IDLE, &sched_param) == -1)
 				error("sched_setparam failed: %s", strerror(errno));
 		} else {
 			error("sched_getparam failed: %s", strerror(errno));

--- a/alsactl/alsactl.c
+++ b/alsactl/alsactl.c
@@ -161,7 +161,7 @@ static void do_nice(int use_nice, int sched_idle)
 	if (sched_idle) {
 		if (sched_getparam(0, &sched_param) >= 0) {
 			sched_param.sched_priority = 0;
-			if (!sched_setscheduler(0, SCHED_IDLE, &sched_param))
+			if (sched_setscheduler(0, SCHED_IDLE, &sched_param))
 				error("sched_setparam failed: %s", strerror(errno));
 		} else {
 			error("sched_getparam failed: %s", strerror(errno));


### PR DESCRIPTION

As man page says: "If successful, the sched_setparam() function shall return zero."
So the if must be without !

Without update I got this output in the syslog (journalctl):
abr 16 09:25:30 mypc alsactl[1652]: alsactl 1.2.2 daemon started
abr 16 09:25:30 mypc alsactl[1652]: /usr/bin/alsactl: do_nice:165sched_setparam failed: No such file or directory

That I think that is a wrong message. The call to sched_setparam is correct.

This is the output with strace:
getpriority(PRIO_PROCESS, 0)            = 20
setpriority(PRIO_PROCESS, 0, 19)        = 0
getpriority(PRIO_PROCESS, 0)            = 1
sched_getparam(0, [0])                  = 0
sched_setscheduler(0, SCHED_IDLE, [0])  = 0
write(2, "/usr/bin/alsactl: do_nice:165: ", 31/usr/bin/alsactl: do_nice:165: ) = 31
write(2, "sched_setparam failed: No such f"..., 48sched_setparam failed: No such file or directory) = 48
write(2, "\n", 1)                       = 1

Call to sched_setscheduler returns 0, so it means that the call was successful.