### PR TITLE
aplay: fix for aborted capture streams

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -2135,7 +2135,9 @@ static ssize_t pcm_read(u_char *data, size_t rcount)
 		count = chunk_size;
 	}
 
-	while (count > 0 && !in_aborting) {
+	while (count > 0) {
+		if (in_aborting)
+			goto abort;
 		if (test_position)
 			do_test_position();
 		check_stdin();
@@ -2161,6 +2163,7 @@ static ssize_t pcm_read(u_char *data, size_t rcount)
 			data += r * bits_per_frame / 8;
 		}
 	}
+abort:
 	return rcount;
 }
 

--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -3206,11 +3206,12 @@ static void capture(char *orig_name)
 			size_t c = (rest <= (off64_t)chunk_bytes) ?
 				(size_t)rest : chunk_bytes;
 			size_t f = c * 8 / bits_per_frame;
-			if (pcm_read(audiobuf, f) != f) {
+			size_t read = pcm_read(audiobuf, f);
+			size_t save;
+			if (read != f)
 				in_aborting = 1;
-				break;
-			}
-			if (xwrite(fd, audiobuf, c) != c) {
+			save = read * bits_per_frame / 8;
+			if (xwrite(fd, audiobuf, save) != save) {
 				perror(name);
 				in_aborting = 1;
 				break;

--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -2174,7 +2174,9 @@ static ssize_t pcm_readv(u_char **data, unsigned int channels, size_t rcount)
 		count = chunk_size;
 	}
 
-	while (count > 0 && !in_aborting) {
+	while (count > 0) {
+		if (in_aborting)
+			goto abort;
 		unsigned int channel;
 		void *bufs[channels];
 		size_t offset = result;
@@ -2206,6 +2208,7 @@ static ssize_t pcm_readv(u_char **data, unsigned int channels, size_t rcount)
 			count -= r;
 		}
 	}
+abort:
 	return rcount;
 }
 


### PR DESCRIPTION
This patch set fixes the issue with capture streams which were aborted by external signal like ctrl+c. Currently functions pcm_read() and pcm_readv() when aborted (in_aborting flag set) return the amount of requested frames instead of those actually read prior to interrupt. The consequence of this is repetition of recent X frames where X stands for amount of frames in one period. This problem is barely visible or rather *audible* when the period is small like few milliseconds because repetition of 1 [ms] of data is not-noticeable however if we use buffer and period sizes in seconds then the problem becomes apparent. 


Example issue -> https://github.com/thesofproject/sof/issues/3189