### PR TITLE
alsabat: fix typo

### DIFF
--- a/bat/alsabat.1
+++ b/bat/alsabat.1
@@ -24,8 +24,8 @@ is actively being developed for future releases.
 
 The hardware testing configuration may require the use of an analog cable
 connecting target to tester machines or a cable to create an analog
-loopback if no loopback mode is not available on the sound hardware that
-is being tested.
+loopback if no loopback mode is available on the sound hardware that is
+being tested.
 An analog loopback cable can be used to connect the "line in" to "line out"
 jacks to create a loopback. If only headphone and mic jacks (or combo jack)
 are available then the following simple circuit can be used to create an


### PR DESCRIPTION
Halve the double negative ‘if no loopback mode is not available’.

Signed-off-by: Tobias Geerinckx-Rice <me@tobias.gr>