### PR TITLE
alsactl: init - add -U option to disable UCM based init

### DIFF
--- a/alsactl/alsactl.c
+++ b/alsactl/alsactl.c
@@ -98,6 +98,7 @@ static struct arg args[] = {
 { 'c', "sched-idle", "set the process scheduling policy to idle (SCHED_IDLE)" },
 #ifdef HAVE_ALSA_USE_CASE_H
 { 'D', "ucm-defaults", "execute also the UCM 'defaults' section" },
+{ 'U', "no-ucm", "don't init with UCM" },
 #endif
 { HEADER, NULL, "Available commands:" },
 { CARDCMD, "store", "save current driver setup for one or each soundcards" },
@@ -269,6 +270,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'D':
 			initflags |= FLAG_UCM_DEFAULTS;
+			break;
+		case 'U':
+			initflags |= FLAG_UCM_DISABLED;
 			break;
 		case 'r':
 			statefile = optarg;

--- a/alsactl/alsactl.h
+++ b/alsactl/alsactl.h
@@ -25,7 +25,8 @@ void error_handler(const char *file, int line, const char *function, int err, co
 #define dbg(args...) do { dbg_(__func__, __LINE__, ##args); }  while (0)
 #endif	
 
-#define FLAG_UCM_DEFAULTS	(1<<0)
+#define FLAG_UCM_DISABLED	(1<<0)
+#define FLAG_UCM_DEFAULTS	(1<<1)
 
 int init(const char *file, int flags, const char *cardname);
 int init_ucm(int flags, int cardno);

--- a/alsactl/init_parse.c
+++ b/alsactl/init_parse.c
@@ -1762,9 +1762,11 @@ int init(const char *filename, int flags, const char *cardname)
 				break;
 			}
 			first = 0;
-			err = init_ucm(flags, card);
-			if (err == 0)
-				continue;
+			if (!(flags & FLAG_UCM_DISABLED)) {
+				err = init_ucm(flags, card);
+				if (err == 0)
+					continue;
+			}
 			err = init_space(&space, card);
 			if (err == 0) {
 				space->rootdir = new_root_dir(filename);
@@ -1787,9 +1789,11 @@ int init(const char *filename, int flags, const char *cardname)
 			error("Cannot find soundcard '%s'...", cardname);
 			goto error;
 		}
-		err = init_ucm(flags, card);
-		if (err == 0)
-			return 0;
+		if (!(flags & FLAG_UCM_DISABLED)) {
+			err = init_ucm(flags, card);
+			if (err == 0)
+				return 0;
+		}
 		memset(&space, 0, sizeof(space));
 		err = init_space(&space, card);
 		if (err == 0) {


### PR DESCRIPTION
The reason is to use it with internal init extra commands like:
  alsactl -U -E CMD=info init

Currently, if there is a valid UCM config for a card the alsactl command exits silently on the init command and don't execute any extra commands because that commands defined in a common init path file _init/00main_ that don't used in case of UCM did the job.