### PR TITLE
amixer: cset: check control is readable before reading it

### DIFF
--- a/amixer/amixer.c
+++ b/amixer/amixer.c
@@ -1165,7 +1165,8 @@ static int cset(int argc, char *argv[], int roflag, int keep_handle)
 	snd_ctl_elem_info_get_id(info, id);     /* FIXME: Remove it when hctl find works ok !!! */
 	if (!roflag) {
 		snd_ctl_elem_value_set_id(control, id);
-		if ((err = snd_ctl_elem_read(handle, control)) < 0) {
+		if (snd_ctl_elem_info_is_readable(info) &&
+		    (err = snd_ctl_elem_read(handle, control)) < 0) {
 			if (ignore_error)
 				return 0;
 			error("Cannot read the given element from control %s\n", card);

--- a/build64-linaro.sh
+++ b/build64-linaro.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cd `dirname $0`
+dir=`pwd`
+
+TOOLCHAIN_DIR=/home/viorel/work/opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu
+
+if test -d ../alsa-lib/utils && ! test -r `aclocal --print-ac-dir`/alsa.m4; then
+  alsa_m4_flags="-I ../alsa-lib/utils"
+fi
+aclocal $alsa_m4_flags $ACLOCAL_FLAGS
+# save original files to avoid stupid modifications by gettextize
+cp Makefile.am Makefile.am.ok
+cp configure.ac configure.ac.ok
+gettextize -c -f --no-changelog
+echo "EXTRA_DIST = gettext.m4" > m4/Makefile.am
+cp Makefile.am.ok Makefile.am
+cp configure.ac.ok configure.ac
+aclocal -I m4 $alsa_m4_flags
+autoheader -f
+automake -f --foreign --copy --add-missing
+touch depcomp		# for older automake
+autoconf -f
+export CFLAGS='-O2 -Wall -pipe -g'
+export LDFLAGS="-L$dir/../alsa-bin/lib"
+export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+
+args="--with-alsa-prefix=$dir/../alsa-bin --with-alsa-inc-prefix=$dir/../alsa-bin/include"
+args="$args --with-systemdsystemunitdir=$dir/../alsa-bin/lib/systemd/system"
+args="$args --with-udev-rules-dir=$dir/../alsa-bin/lib/udev/rules.d"
+args="$args --disable-nls --disable-alsamixer --disable-xmlto"
+./configure --host=aarch64-linux-gnu --prefix=$dir/../alsa-bin $args || exit 1
+
+make clean
+make
+make install

--- a/configure.ac
+++ b/configure.ac
@@ -3,12 +3,12 @@ AC_PREREQ(2.59)
 AC_INIT(alsa-utils, 1.2.4)
 AC_CONFIG_SRCDIR([aplay/aplay.c])
 AC_PREFIX_DEFAULT(/usr)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 AM_MAINTAINER_MODE([enable])
 
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_GNU_GETTEXT_VERSION([0.21])
 
 dnl Checks for programs.
 


### PR DESCRIPTION
In current implementation cset command will fail on
controls which are not readable, ie just writable.
Check readable state prior calling snd_ctl_elem_read.

Signed-off-by: Viorel Suman <viorel.suman@nxp.com>