### PR TITLE
alsamixer: use background color instead of COLOR_BLACK

### DIFF
--- a/alsamixer/colors.c
+++ b/alsamixer/colors.c
@@ -50,11 +50,11 @@ void init_colors(int use_color)
 		start_color();
 		use_default_colors();
 
-		get_color_pair(COLOR_CYAN, COLOR_BLACK); // COLOR_PAIR(1)
-		get_color_pair(COLOR_YELLOW, COLOR_BLACK);
+		get_color_pair(COLOR_CYAN, -1); // COLOR_PAIR(1)
+		get_color_pair(COLOR_YELLOW, -1);
 		get_color_pair(COLOR_WHITE, COLOR_GREEN);
-		get_color_pair(COLOR_RED, COLOR_BLACK);
-		get_color_pair(COLOR_WHITE, COLOR_BLACK);
+		get_color_pair(COLOR_RED, -1);
+		get_color_pair(COLOR_WHITE, -1);
 		get_color_pair(COLOR_WHITE, COLOR_BLUE);
 		get_color_pair(COLOR_RED, COLOR_BLUE);
 		get_color_pair(COLOR_GREEN, COLOR_GREEN);


### PR DESCRIPTION
Hi! I have a cosmetic "improvement" I'd like to share. Scare quotes because this is possibly opinionated, but I'd still like to know what you think.

I think on typical terminals, COLOR_BLACK is the same or quite similar to the background color, so this does not make much of a difference. But on "solarized" color schemes and similar, the COLOR_BLACK may be quite different from the background color, so in my opinion it looks odd to have the alsamixer panel stand out this way. For example, I'm using the "Nord" color scheme on a pitch black #000000 background, and here's how the mixer looks with/without this patch (blank terminal, htop, and ncmpcpp also provided for comparison):

![image](https://user-images.githubusercontent.com/52847440/107131140-dbf46500-6888-11eb-938a-9a3258bf7184.png)

As you can see, the current alsamixer in the center looks a bit strange and sticks out against my chosen background color and the other TUIs I'm using. Htop and ncmpcpp agree on using the builtin `-1` background color for their own backgrounds, but alsamixer uses COLOR_BLACK which stands out from the actual background. The alsamixer on the bottom right is using this patch, and blends in seamlessly.

Again, this is just my opinion! Feel free to close if this is wrong or superfluous. Nonetheless, I thought I'd share this patch, in case anyone else feels the same way.