### PR TITLE
amixer: Expand on channel docs in man page

### DIFF
--- a/amixer/amixer.1
+++ b/amixer/amixer.1
@@ -44,11 +44,12 @@ value, respectively.
 The parameters \fIcap, nocap, mute, unmute, toggle\fP are used to
 change capture (recording) and muting for the group specified.
 
-The optional modifiers can be put as extra parameters to specify
-the stream direction or channels to apply.
+The optional modifiers can be put as extra parameters before the value to
+specify the stream direction or channels to apply.
 The modifiers \fIplayback\fP and \fIcapture\fP specify the stream,
-and the modifiers \fIfront, rear, center, woofer\fP are used to specify
-channels to be changed. 
+and the modifiers \fIfront, frontleft, frontright, frontcenter, center,
+rear, rearright, rearleft, woofer\fP are used to specify channels to be
+changed.
 
 A simple mixer control must be specified. Only one device can be controlled
 at a time.


### PR DESCRIPTION
Add missing channel params to the amixer man page. Also call out that
the channel param must come before the value to take effect.

signed-off-by: Matthew Campbell <mcampbell@izotope.com>