### PR TITLE
alsactl: init command now honors -g flag as well

### DIFF
--- a/alsactl/alsactl.1
+++ b/alsactl/alsactl.1
@@ -83,7 +83,7 @@ as much as possible.  This option is set as default now.
 
 .TP
 \fI\-g, \-\-ignore\fP
-Used with store and restore commands. Do not show 'No soundcards found'
+Used with store, restore and init commands. Do not show 'No soundcards found'
 and do not set an error exit code when soundcards are not installed.
 
 .TP


### PR DESCRIPTION
As of #75 this commit aligns the manpage with the new behaviour.