### PR TITLE
man: Correct "rate" option

### DIFF
--- a/alsaloop/alsaloop.1
+++ b/alsaloop/alsaloop.1
@@ -79,7 +79,7 @@ Default format is S16_LE.
 Channel count specification. Default value is 2.
 
 .TP
-\fI\-c <rate>\fP | \fI\-\-rate=<rate>\fP
+\fI\-r <rate>\fP | \fI\-\-rate=<rate>\fP
 
 Rate specification. Default value is 48000 (Hz).
 


### PR DESCRIPTION
Resolves https://github.com/alsa-project/alsa-utils/issues/82
Change "rate" option from "-c" to "-r".