### PR TITLE
alsa-utils: axfer: fix regression of timeout in timer-based scheduling model

### DIFF
--- a/axfer/xfer-libasound-timer-mmap.c
+++ b/axfer/xfer-libasound-timer-mmap.c
@@ -171,7 +171,8 @@ static int timer_mmap_process_frames(struct libasound_state *state,
 		// exactly the mechanism yet.
 		err = xfer_libasound_wait_event(state, timeout_msec,
 						&revents);
-		if (err < 0)
+		// MEMO: timeout is expected since the above call is just to measure time elapse.
+		if (err < 0 && err != -ETIMEDOUT)
 			return err;
 		if (revents & POLLERR) {
 			// TODO: error reporting.


### PR DESCRIPTION
In timer-based scheduling model, event waiting is just to measure time
elapse since no event is expected to occur. However, as a result to
applying commit e5e6a7838b06, -ETIMEDOUT returns in the case and
the caller handles it as error. This results in disorder of the
scheduling model.

This commit fixes the regression so that the -ETIMEDOUT case is expected.

Reported-by: Amadeusz Sławiński <amadeuszx.slawinski@linux.intel.com>
Link: https://lore.kernel.org/alsa-devel/687f9871-7484-1370-04d1-9c968e86f72b@linux.intel.com/
Fixes: e5e6a7838b06 ("axfer: return ETIMEDOUT when no event occurs after waiter expiration")
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>