### PR TITLE
topology: fix potential null pointer from strchr

### DIFF
--- a/topology/pre-process-dapm.c
+++ b/topology/pre-process-dapm.c
@@ -146,6 +146,11 @@ static int tplg_pp_get_widget_name(struct tplg_pre_processor *tplg_pp,
 
 	/* get class name */
 	args = strchr(string, '.');
+	if (!args) {
+		SNDERR("Error getting class name for %s\n", string);
+		return -EINVAL;
+	}
+
 	class_name = calloc(1, strlen(string) - strlen(args) + 1);
 	if (!class_name)
 		return -ENOMEM;

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -492,6 +492,11 @@ static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 	}
 
 	type = strchr(token_ref, '.');
+	if(!type) {
+		SNDERR("Error getting type for %s\n", token_ref);
+		return -EINVAL;
+	}
+
 	token = calloc(1, strlen(token_ref) - strlen(type) + 1);
 	if (!token)
 		return -ENOMEM;


### PR DESCRIPTION
This patch adds check to the return pointer from strchr,
because it may be null and cause segment fault, if component
is not properly constructed.

Signed-off-by: Chao Song <chao.song@linux.intel.com>