### PR TITLE
utils.c: Include limits.h explicitly to fix build on musl

### DIFF
--- a/alsactl/utils.c
+++ b/alsactl/utils.c
@@ -30,6 +30,7 @@
 #include <syslog.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <limits.h>
 #include "alsactl.h"
 
 int file_map(const char *filename, char **buf, size_t *bufsize)


### PR DESCRIPTION
Fixes:
| ../../alsa-utils-1.2.5/alsactl/utils.c: In function 'snd_card_clean_cfgdir':
| ../../alsa-utils-1.2.5/alsactl/utils.c:309:19: error: 'PATH_MAX' undeclared (first use in this function)
|   309 |         char path[PATH_MAX];
|       |                   ^~~~~~~~
| ../../alsa-utils-1.2.5/alsactl/utils.c:309:19: note: each undeclared identifier is reported only once for each function it appears in

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>