### PR TITLE
load_state: Only delete config if one was loaded

### DIFF
--- a/alsactl/state.c
+++ b/alsactl/state.c
@@ -1624,7 +1624,7 @@ int load_state(const char *cfgdir, const char *file,
 {
 	int err, finalerr = 0, open_failed;
 	struct snd_card_iterator iter;
-	snd_config_t *config;
+	snd_config_t *config = NULL;
 	const char *cardname1;
 
 	err = load_configuration(file, &config, &open_failed);
@@ -1676,7 +1676,8 @@ int load_state(const char *cfgdir, const char *file,
 	}
 	err = finalerr ? finalerr : snd_card_iterator_error(&iter);
 out:
-	snd_config_delete(config);
+	if (config)
+		snd_config_delete(config);
 	snd_config_update_free_global();
 	return err;
 }


### PR DESCRIPTION
If load_configuration fails with open_failed == true, load_state will
jump to the out label without config being initialized and pass this
uninitialized config value to snd_config_delete. This commit fixes this
issue by initializing config with NULL and checking if it is non-null
before invoking snd_config_delete.

Signed-off-by: Sören Tempel <soeren+git@soeren-tempel.net>

---

See also https://gitlab.alpinelinux.org/alpine/aports/-/issues/12729