### PR TITLE
added an option to aseqnet to optionally set the midi process name

### DIFF
--- a/seq/aseqnet/README.aseqnet
+++ b/seq/aseqnet/README.aseqnet
@@ -50,4 +50,6 @@ The available options are:
   -s addr : explicit read-subscription to the given address
             (client:addr).
   -d addr : explicit write-subscription to the given address.
+  -n name : specify the midi name of the process.
+            Default value is either 'Net Client' or 'Net Server'.
   -v      : verbose mode.

--- a/seq/aseqnet/aseqnet.1
+++ b/seq/aseqnet/aseqnet.1
@@ -70,6 +70,9 @@ Subscribe to the given address for read automatically.
 .B \-d addr
 Subscribe to the given address for write automatically.
 .TP
+.B \-n name
+Specify the midi name of the process.
+.TP
 .B \-v
 Verbose mode.
 


### PR DESCRIPTION
This option allows to run multiple instances of aseqnet without having
to double check the assigned port number, since each one can get spawned
with a unique name.

The patch is pretty minimal and clean, thopefully here shouldn't be troubles 
merging it.