### PR TITLE
Add support for automatic attributes in Topology2.0

### DIFF
--- a/topology/pre-process-dapm.c
+++ b/topology/pre-process-dapm.c
@@ -406,7 +406,7 @@ int tplg_build_dapm_route_object(struct tplg_pre_processor *tplg_pp, snd_config_
 		goto err;
 	}
 
-	line_str = tplg_snprintf("%s, %s, %s", src_widget_name, control, sink_widget_name);
+	line_str = tplg_snprintf("%s, %s, %s", sink_widget_name, control, src_widget_name);
 	if (!line_str) {
 		ret = -ENOMEM;
 		goto err;

--- a/topology/pre-process-dapm.c
+++ b/topology/pre-process-dapm.c
@@ -115,6 +115,10 @@ static int tplg_build_control(struct tplg_pre_processor *tplg_pp, snd_config_t *
 	if (ret < 0)
 		return ret;
 
+	ret = tplg_add_object_data(tplg_pp, obj_cfg, cfg, NULL);
+	if (ret < 0)
+		SNDERR("Failed to add data section for %s\n", name);
+
 	return tplg_parent_update(tplg_pp, parent, type, name);
 }
 

--- a/topology/pre-process-dapm.c
+++ b/topology/pre-process-dapm.c
@@ -422,3 +422,112 @@ err:
 	free(sink_widget_name);
 	return ret;
 }
+
+static int tplg_get_sample_size_from_format(const char *format)
+{
+	if (!strcmp(format, "s32le") || !strcmp(format, "s24le") || !strcmp(format, "float"))
+		return 4;
+
+	if (!strcmp(format, "s16le"))
+		return 2;
+
+	SNDERR("Unsupported format: %s\n", format);
+	return -EINVAL;
+}
+
+int tplg_update_buffer_auto_attr(struct tplg_pre_processor *tplg_pp,
+				 snd_config_t *buffer_cfg, snd_config_t *parent)
+{
+	snd_config_iterator_t i, next;
+	snd_config_t *n, *pipeline_cfg, *child;
+	const char *buffer_id, *format;
+	long periods, channels, sample_size;
+	long sched_period, rate, frames;
+	long buffer_size;
+	int err;
+
+	if (snd_config_get_id(buffer_cfg, &buffer_id) < 0)
+		return -EINVAL;
+
+	if (!parent) {
+		SNDERR("No parent for buffer %s\n", buffer_id);
+		return -EINVAL;
+	}
+
+	/* acquire attributes from buffer config */
+	snd_config_for_each(i, next, buffer_cfg) {
+		const char *id;
+
+		n = snd_config_iterator_entry(i);
+		if (snd_config_get_id(n, &id) < 0)
+			continue;
+
+		if (!strcmp(id, "periods")) {
+			if (snd_config_get_integer(n, &periods)) {
+				SNDERR("Invalid number of periods for buffer %s\n", buffer_id);
+				return -EINVAL;
+			}
+		}
+
+		if (!strcmp(id, "channels")) {
+			if (snd_config_get_integer(n, &channels)) {
+				SNDERR("Invalid number of channels for buffer %s\n", buffer_id);
+				return -EINVAL;
+			}
+		}
+
+		if (!strcmp(id, "format")) {
+			if (snd_config_get_string(n, &format)) {
+				SNDERR("Invalid format for buffer %s\n", buffer_id);
+				return -EINVAL;
+			}
+		}
+	}
+
+	pipeline_cfg = tplg_object_get_instance_config(tplg_pp, parent);
+
+	/* acquire some other attributes from parent pipeline config */
+	snd_config_for_each(i, next, pipeline_cfg) {
+		const char *id;
+
+		n = snd_config_iterator_entry(i);
+		if (snd_config_get_id(n, &id) < 0)
+			continue;
+
+		if (!strcmp(id, "period")) {
+			if (snd_config_get_integer(n, &sched_period)) {
+				SNDERR("Invalid period for buffer %s\n", buffer_id);
+				return -EINVAL;
+			}
+		}
+
+		if (!strcmp(id, "rate")) {
+			if (snd_config_get_integer(n, &rate)) {
+				SNDERR("Invalid rate for buffer %s\n", buffer_id);
+				return -EINVAL;
+			}
+		}
+	}
+
+	/* calculate buffer size */
+	sample_size = tplg_get_sample_size_from_format(format);
+	if (sample_size < 0) {
+		SNDERR("Invalid sample size value for %s\n", buffer_id);
+		return sample_size;
+	}
+	frames = (rate * sched_period) / 1000000;
+	buffer_size = periods * sample_size * channels * frames;
+
+	/* add size child config to buffer config */
+	err = tplg_config_make_add(&child, "size", SND_CONFIG_TYPE_INTEGER, buffer_cfg);
+	if (err < 0) {
+		SNDERR("Error creating size config for %s\n", buffer_id);
+		return err;
+	}
+
+	err = snd_config_set_integer(child, buffer_size);
+	if (err < 0)
+		SNDERR("Error setting size config for %s\n", buffer_id);
+
+	return err;
+}

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -118,12 +118,16 @@ int tplg_parent_update(struct tplg_pre_processor *tplg_pp, snd_config_t *parent,
 
 	/* get section config */
 	if (!strcmp(section_name, "tlv")) {
-		ret = tplg_config_make_add(&item_config, section_name,
-					  SND_CONFIG_TYPE_STRING, cfg);
-		if (ret < 0) {
-			SNDERR("Error creating section config widget %s for %s\n",
-			       section_name, parent_name);
-			return ret;
+		/* set tlv name if config exists already */
+		ret = snd_config_search(cfg, section_name, &item_config);
+			if (ret < 0) {
+			ret = tplg_config_make_add(&item_config, section_name,
+						  SND_CONFIG_TYPE_STRING, cfg);
+			if (ret < 0) {
+				SNDERR("Error creating section config widget %s for %s\n",
+				       section_name, parent_name);
+				return ret;
+			}
 		}
 
 		return snd_config_set_string(item_config, item_name);

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -944,6 +944,8 @@ const struct build_function_map object_build_map[] = {
 	 &hwcfg_config},
 	{"Base", "fe_dai", "dai", &tplg_build_fe_dai_object, NULL, &fe_dai_config},
 	{"Base", "route", "SectionGraph", &tplg_build_dapm_route_object, NULL, NULL},
+	{"Widget", "buffer", "SectionWidget", &tplg_build_generic_object,
+	 tplg_update_buffer_auto_attr, &widget_config},
 	{"Widget", "", "SectionWidget", &tplg_build_generic_object, NULL, &widget_config},
 	{"Control", "mixer", "SectionControlMixer", &tplg_build_mixer_control, NULL,
 	 &mixer_control_config},

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -667,8 +667,8 @@ static int tplg_pp_add_object_data_section(struct tplg_pre_processor *tplg_pp,
 	return snd_config_set_string(child, data_name);
 }
 
-static int tplg_add_object_data(struct tplg_pre_processor *tplg_pp, snd_config_t *obj_cfg,
-				snd_config_t *top, const char *array_name)
+int tplg_add_object_data(struct tplg_pre_processor *tplg_pp, snd_config_t *obj_cfg,
+			 snd_config_t *top, const char *array_name)
 {
 	snd_config_iterator_t i, next;
 	snd_config_t *data_cfg, *class_cfg, *n, *obj;

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -883,16 +883,18 @@ int tplg_build_object_from_template(struct tplg_pre_processor *tplg_pp, snd_conf
 		*wtop = top;
 	} else {
 		*wtop = tplg_find_config(top, object_name);
-		if (!(*wtop)) {
-			ret = tplg_config_make_add(wtop, object_name, SND_CONFIG_TYPE_COMPOUND,
-						   top);
-			if (ret < 0) {
-				SNDERR("Error creating config for %s\n", object_name);
-				return ret;
-			}
+		if (*wtop)
+			goto template;
+
+		ret = tplg_config_make_add(wtop, object_name, SND_CONFIG_TYPE_COMPOUND,
+					   top);
+		if (ret < 0) {
+			SNDERR("Error creating config for %s\n", object_name);
+			return ret;
 		}
 	}
 
+template:
 	/* create template config */
 	if (!map->template_items)
 		return 0;

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -87,6 +87,10 @@ int tplg_parent_update(struct tplg_pre_processor *tplg_pp, snd_config_t *parent,
 	char *item_id;
 	int ret, id = 0;
 
+	/* Nothing to do if parent is NULL */
+	if (!parent)
+		return 0;
+
 	child = tplg_object_get_instance_config(tplg_pp, parent);
 	ret = snd_config_search(child, "name", &cfg);
 	if (ret < 0) {
@@ -966,6 +970,7 @@ const struct config_template_items mixer_control_config = {
 
 const struct config_template_items bytes_control_config = {
 	.int_config_ids = {"index", "base", "num_regs", "max", "mask"},
+	.compound_config_ids = {"access"}
 };
 
 const struct config_template_items scale_config = {

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -472,11 +472,11 @@ static snd_config_t *tplg_object_lookup_in_config(struct tplg_pre_processor *tpl
 static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 					    snd_config_t *class_cfg,
 					    snd_config_t *attr, char *data_name,
-					    const char *token_ref)
+					    const char *token_ref, const char *array_name)
 {
 	snd_config_t *top, *tuple_cfg, *child, *cfg, *new;
 	const char *id;
-	char *token, *type;
+	char *token, *type, *str;
 	long tuple_value;
 	int ret;
 
@@ -502,6 +502,15 @@ static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 	if (!token)
 		return -ENOMEM;
 	snprintf(token, strlen(token_ref) - strlen(type) + 1, "%s", token_ref);
+
+	if (!array_name)
+		str = strdup(type + 1);
+	else
+		str = tplg_snprintf("%s.%s", type + 1, array_name);
+	if (!str) {
+		ret = -ENOMEM;
+		goto free;
+	}
 
 	tuple_cfg = tplg_find_config(top, data_name);
 	if (!tuple_cfg) {
@@ -532,26 +541,29 @@ static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 			goto err;
 		}
 
-		ret = tplg_config_make_add(&cfg, type + 1, SND_CONFIG_TYPE_COMPOUND,
+		ret = tplg_config_make_add(&cfg, str, SND_CONFIG_TYPE_COMPOUND,
 					  child);
 		if (ret < 0) {
 			SNDERR("Error creating tuples type config for '%s'\n", data_name);
 			goto err;
 		}
 	} else {
-		char *id;
+		snd_config_t *tuples_cfg;
 
-		id = tplg_snprintf("tuples.%s", type + 1);
-		if (!id) {
-			ret = -ENOMEM;
+		ret = snd_config_search(tuple_cfg, "tuples" , &tuples_cfg);
+		if (ret < 0) {
+			SNDERR("can't find tuples config in %s\n", data_name);
 			goto err;
 		}
 
-		ret = snd_config_search(tuple_cfg, id , &cfg);
-		free(id);
-		if (ret < 0) {
-			SNDERR("can't find type config %s\n", type + 1);
-			goto err;
+		cfg = tplg_find_config(tuples_cfg, str);
+		if (!cfg) {
+			ret = tplg_config_make_add(&cfg, str, SND_CONFIG_TYPE_COMPOUND,
+						  tuples_cfg);
+			if (ret < 0) {
+				SNDERR("Error creating tuples config for '%s' and type name %s\n", data_name, str);
+				goto err;
+			}
 		}
 	}
 
@@ -584,10 +596,9 @@ static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 	}
 
 	ret = snd_config_add(cfg, new);
-	if (ret < 0)
-		goto err;
-
 err:
+	free(str);
+free:
 	free(token);
 	return ret;
 }
@@ -653,7 +664,7 @@ static int tplg_pp_add_object_data_section(struct tplg_pre_processor *tplg_pp,
 }
 
 static int tplg_add_object_data(struct tplg_pre_processor *tplg_pp, snd_config_t *obj_cfg,
-				snd_config_t *top)
+				snd_config_t *top, const char *array_name)
 {
 	snd_config_iterator_t i, next;
 	snd_config_t *data_cfg, *class_cfg, *n, *obj;
@@ -704,7 +715,7 @@ static int tplg_add_object_data(struct tplg_pre_processor *tplg_pp, snd_config_t
 		}
 
 		ret = tplg_pp_add_object_tuple_section(tplg_pp, class_cfg, n, data_cfg_name,
-						       token);
+						       token, array_name);
 		if (ret < 0) {
 			SNDERR("Failed to add data section %s\n", data_cfg_name);
 			free(data_cfg_name);
@@ -760,6 +771,60 @@ static int tplg_object_add_attributes(snd_config_t *dst, snd_config_t *template,
 
 static const struct build_function_map *tplg_object_get_map(struct tplg_pre_processor *tplg_pp,
 							    snd_config_t *obj);
+
+/* Add object attributes to the private data of the parent object config */
+static int tplg_build_parent_data(struct tplg_pre_processor *tplg_pp, snd_config_t *obj_cfg,
+				  snd_config_t *parent)
+{
+	snd_config_t *obj, *parent_obj, *section_cfg, *top;
+	const struct build_function_map *map;
+	const char *id, *parent_id;
+	int ret;
+
+	/* nothing to do if parent is NULL */
+	if (!parent)
+		return 0;
+
+	obj = tplg_object_get_instance_config(tplg_pp, obj_cfg);
+	parent_obj = tplg_object_get_instance_config(tplg_pp, parent);
+
+	/* get object ID */
+	if (snd_config_get_id(obj, &id) < 0) {
+		SNDERR("Invalid ID for object\n");
+		return -EINVAL;
+	}
+
+	/* get parent object name or ID */
+	parent_id = tplg_object_get_name(tplg_pp, parent_obj);
+	if (!parent_id) {
+		ret = snd_config_get_id(parent_obj, &parent_id);
+		if (ret < 0) {
+			SNDERR("Invalid ID for parent of object %s\n", id);
+			return ret;
+		}
+	}
+
+	map = tplg_object_get_map(tplg_pp, parent);
+	if (!map) {
+		SNDERR("Parent object %s not supported\n", parent_id);
+		return -EINVAL;
+	}
+
+	/* find parent config with ID */
+	ret = snd_config_search(tplg_pp->output_cfg, map->section_name, &section_cfg);
+	if (ret < 0) {
+		SNDERR("No SectionBE found\n");
+		return ret;
+	}
+
+	top = tplg_find_config(section_cfg, parent_id);
+	if (!top) {
+		SNDERR("SectionBE %s not found\n", parent_id);
+		return -EINVAL;
+	}
+
+	return tplg_add_object_data(tplg_pp, obj_cfg, top, id);
+}
 
 /*
  * Function to create a new "section" config based on the template. The new config will be
@@ -858,7 +923,7 @@ static int tplg_build_generic_object(struct tplg_pre_processor *tplg_pp, snd_con
 	if (ret < 0)
 		return ret;
 
-	ret = tplg_add_object_data(tplg_pp, obj_cfg, wtop);
+	ret = tplg_add_object_data(tplg_pp, obj_cfg, wtop, NULL);
 	if (ret < 0)
 		SNDERR("Failed to add data section for %s\n", name);
 
@@ -1464,28 +1529,31 @@ static int tplg_build_object(struct tplg_pre_processor *tplg_pp, snd_config_t *n
 		return ret;
 	}
 
-	/* skip object if not supported and pre-process its child objects */
+	/*
+	 * Build objects if object type is supported.
+	 * If not, process object attributes and add to parent's data section
+	 */
 	map = tplg_object_get_map(tplg_pp, new_obj);
-	if (!map)
-		goto child;
+	if (map) {
+		builder = map->builder;
 
-	/* update automatic attribute for current object */
-	auto_attr_updater = map->auto_attr_updater;
-	if(auto_attr_updater) {
-		ret = auto_attr_updater(tplg_pp, obj_local, parent);
-		if (ret < 0) {
-			SNDERR("Failed to update automatic attributes for %s\n", id);
-			return ret;
+		/* update automatic attribute for current object */
+		auto_attr_updater = map->auto_attr_updater;
+		if(auto_attr_updater) {
+			ret = auto_attr_updater(tplg_pp, obj_local, parent);
+			if (ret < 0) {
+				SNDERR("Failed to update automatic attributes for %s\n", id);
+				return ret;
+			}
 		}
+	} else {
+		builder = &tplg_build_parent_data;
 	}
 
-	/* build the object and save the sections to the output config */
-	builder = map->builder;
 	ret = builder(tplg_pp, new_obj, parent);
 	if (ret < 0)
 		return ret;
 
-child:
 	/* create child objects in the object instance */
 	ret = tplg_object_pre_process_children(tplg_pp, new_obj, obj_local);
 	if (ret < 0) {

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -1598,16 +1598,90 @@ int tplg_pre_process_objects(struct tplg_pre_processor *tplg_pp, snd_config_t *c
 		if (snd_config_get_id(n, &class_name) < 0)
 			continue;
 		snd_config_for_each(i2, next2, n) {
+			snd_config_t *temp_n2;
+
 			n2 = snd_config_iterator_entry(i2);
 			if (snd_config_get_id(n2, &id) < 0) {
 				SNDERR("Invalid id for object\n");
 				return -EINVAL;
 			}
 
-			/* create a temp config for object with class type as the root node */
-			ret = snd_config_make(&_obj_type, class_type, SND_CONFIG_TYPE_COMPOUND);
+			ret = snd_config_copy(&temp_n2, n2);
 			if (ret < 0)
 				return ret;
+
+			/*
+			 * An object declared within a class definition as follows:
+			 * Class.Pipeline.volume-playback {
+			 * 	Object.Widget.pga.0 {
+			 * 		ramp_step_ms 250
+            		 * 	}
+			 * }
+			 * 
+			 * While instantiating the volume-pipeline class, the pga object
+			 * could be modified as follows:
+			 * Object.Pipeline.volume-playback.0 {
+			 * 	Object.Widget.pga.0 {
+			 * 		format "s24le"
+			 * 	}
+			 * }
+			 * When building the pga.0 object in the class definition, merge
+			 * the attributes declared in the volume-playback.0 object to create
+			 * a new config as follows to make sure that all attributes are
+			 * set for the pga object.
+			 * Object.Widget.pga.0 {
+			 * 	ramp_step_ms 250
+			 * 	format "s24le"
+			 * }
+			 */ 
+
+			if (parent) {
+				snd_config_t *parent_instance, *parent_obj, *temp;
+				char *obj_cfg_name;
+
+				obj_cfg_name = tplg_snprintf("%s%s.%s.%s", "Object.",
+							     class_type, class_name, id);
+
+				/* search for object instance in the parent */
+				parent_instance = tplg_object_get_instance_config(tplg_pp, parent);
+				if (!parent_instance)
+					goto temp_cfg;
+
+				ret = snd_config_search(parent_instance, obj_cfg_name, &parent_obj);
+				free(obj_cfg_name);
+				if (ret < 0)
+					goto temp_cfg;
+
+				/* don't merge if the object configs are the same */
+				if (parent_obj == n2)
+					goto temp_cfg;
+
+				/* create a temp config copying the parent object config */
+				ret = snd_config_copy(&temp, parent_obj);
+				if (ret < 0) {
+					snd_config_delete(temp_n2);
+					return ret;
+				}
+
+				/*
+				 * Merge parent object with the current object instance.
+				 * temp will be deleted by merge
+				 */
+				ret = snd_config_merge(temp_n2, temp, false);
+				if (ret < 0) {
+					SNDERR("error merging parent object config for %s.%s.%s\n",
+					       class_type, class_name, id);
+					snd_config_delete(temp_n2);
+					return ret;
+				}
+			}
+temp_cfg:
+			/* create a temp config for object with class type as the root node */
+			ret = snd_config_make(&_obj_type, class_type, SND_CONFIG_TYPE_COMPOUND);
+			if (ret < 0) {
+				snd_config_delete(temp_n2);
+				return ret;
+			}
 
 			ret = snd_config_make(&_obj_class, class_name, SND_CONFIG_TYPE_COMPOUND);
 			if (ret < 0)
@@ -1619,7 +1693,7 @@ int tplg_pre_process_objects(struct tplg_pre_processor *tplg_pp, snd_config_t *c
 				goto err;
 			}
 
-			ret = snd_config_copy(&_obj, n2);
+			ret = snd_config_copy(&_obj, temp_n2);
 			if (ret < 0)
 				goto err;
 
@@ -1635,6 +1709,7 @@ int tplg_pre_process_objects(struct tplg_pre_processor *tplg_pp, snd_config_t *c
 				SNDERR("Error building object %s.%s.%s\n",
 				       class_type, class_name, id);
 err:
+			snd_config_delete(temp_n2);
 			snd_config_delete(_obj_type);
 			if (ret < 0)
 				return ret;

--- a/topology/pre-processor.c
+++ b/topology/pre-processor.c
@@ -149,7 +149,7 @@ static int pre_process_config(struct tplg_pre_processor *tplg_pp, snd_config_t *
 		snd_config_for_each(i2, next2, n) {
 			n2 = snd_config_iterator_entry(i2);
 
-			if (snd_config_get_id(n, &id) < 0)
+			if (snd_config_get_id(n2, &id) < 0)
 				continue;
 
 			if (snd_config_get_type(n2) != SND_CONFIG_TYPE_COMPOUND) {

--- a/topology/pre-processor.h
+++ b/topology/pre-processor.h
@@ -81,6 +81,8 @@ int tplg_build_pcm_caps_object(struct tplg_pre_processor *tplg_pp,
 			       snd_config_t *obj_cfg, snd_config_t *parent);
 int tplg_parent_update(struct tplg_pre_processor *tplg_pp, snd_config_t *parent,
 			  const char *section_name, const char *item_name);
+int tplg_update_buffer_auto_attr(struct tplg_pre_processor *tplg_pp,
+				 snd_config_t *buffer_cfg, snd_config_t *parent);
 
 /* object helpers */
 int tplg_pre_process_objects(struct tplg_pre_processor *tplg_pp, snd_config_t *cfg,

--- a/topology/pre-processor.h
+++ b/topology/pre-processor.h
@@ -35,11 +35,15 @@ struct config_template_items {
 typedef int (*build_func)(struct tplg_pre_processor *tplg_pp, snd_config_t *obj,
 			  snd_config_t *parent);
 
+typedef int (*update_auto_attr_func)(struct tplg_pre_processor *tplg_pp,
+			  snd_config_t *obj, snd_config_t *parent);
+
 struct build_function_map {
 	char *class_type;
 	char *class_name;
 	char *section_name;
 	build_func builder;
+	update_auto_attr_func auto_attr_updater;
 	const struct config_template_items *template_items;
 };
 

--- a/topology/pre-processor.h
+++ b/topology/pre-processor.h
@@ -83,6 +83,8 @@ int tplg_parent_update(struct tplg_pre_processor *tplg_pp, snd_config_t *parent,
 			  const char *section_name, const char *item_name);
 int tplg_update_buffer_auto_attr(struct tplg_pre_processor *tplg_pp,
 				 snd_config_t *buffer_cfg, snd_config_t *parent);
+int tplg_add_object_data(struct tplg_pre_processor *tplg_pp, snd_config_t *obj_cfg,
+			 snd_config_t *top, const char *array_name);
 
 /* object helpers */
 int tplg_pre_process_objects(struct tplg_pre_processor *tplg_pp, snd_config_t *cfg,


### PR DESCRIPTION
Add support for automatic attributes in Topology2.0 and also add support for processing objects that are simply used to
update the parent object's private data.
