### PR TITLE
topology: Add option to pass pre-processor definitions

### DIFF
--- a/topology/topology.c
+++ b/topology/topology.c
@@ -234,7 +234,8 @@ static int dump(const char *source_file, const char *output_file, int cflags, in
 }
 
 /* Convert Topology2.0 conf to the existing conf syntax */
-static int pre_process_conf(const char *source_file, const char *output_file)
+static int pre_process_conf(const char *source_file, const char *output_file,
+			    const char *pre_processor_defs)
 {
 	struct tplg_pre_processor *tplg_pp;
 	size_t config_size;
@@ -254,7 +255,7 @@ static int pre_process_conf(const char *source_file, const char *output_file)
 	}
 
 	/* pre-process conf file */
-	err = pre_process(tplg_pp, config, config_size);
+	err = pre_process(tplg_pp, config, config_size, pre_processor_defs);
 
 	/* free pre-processor */
 	free_pre_preprocessor(tplg_pp);
@@ -262,7 +263,8 @@ static int pre_process_conf(const char *source_file, const char *output_file)
 	return err;
 }
 
-static int compile(const char *source_file, const char *output_file, int cflags)
+static int compile(const char *source_file, const char *output_file, int cflags,
+		   const char *pre_processor_defs)
 {
 	struct tplg_pre_processor *tplg_pp = NULL;
 	snd_tplg_t *tplg;
@@ -284,7 +286,7 @@ static int compile(const char *source_file, const char *output_file, int cflags)
 		init_pre_precessor(&tplg_pp, SND_OUTPUT_BUFFER, NULL);
 
 		/* pre-process conf file */
-		err = pre_process(tplg_pp, config, config_size);
+		err = pre_process(tplg_pp, config, config_size, pre_processor_defs);
 		if (err) {
 			free_pre_preprocessor(tplg_pp);
 			free(config);
@@ -353,7 +355,7 @@ static int decode(const char *source_file, const char *output_file,
 
 int main(int argc, char *argv[])
 {
-	static const char short_options[] = "hc:d:n:u:v:o:pP:sgxzV";
+	static const char short_options[] = "hc:d:n:u:v:o:pP:sgxzVD:";
 	static const struct option long_options[] = {
 		{"help", 0, NULL, 'h'},
 		{"verbose", 1, NULL, 'v'},
@@ -372,6 +374,7 @@ int main(int argc, char *argv[])
 	};
 	char *source_file = NULL;
 	char *output_file = NULL;
+	const char *pre_processor_defs = NULL;
 	int c, err, op = 'c', cflags = 0, dflags = 0, sflags = 0, option_index;
 
 #ifdef ENABLE_NLS
@@ -423,6 +426,9 @@ int main(int argc, char *argv[])
 		case 'x':
 			sflags |= SND_TPLG_SAVE_NOCHECK;
 			break;
+		case 'D':
+			pre_processor_defs = optarg;
+			break;
 		case 'V':
 			version(argv[0]);
 			return 0;
@@ -448,13 +454,13 @@ int main(int argc, char *argv[])
 
 	switch (op) {
 	case 'c':
-		err = compile(source_file, output_file, cflags);
+		err = compile(source_file, output_file, cflags, pre_processor_defs);
 		break;
 	case 'd':
 		err = decode(source_file, output_file, cflags, dflags, sflags);
 		break;
 	case 'P':
-		err = pre_process_conf(source_file, output_file);
+		err = pre_process_conf(source_file, output_file, pre_processor_defs);
 		break;
 	default:
 		err = dump(source_file, output_file, cflags, sflags);

--- a/topology/topology.h
+++ b/topology/topology.h
@@ -27,7 +27,8 @@ struct tplg_pre_processor {
 	snd_output_t *dbg_output;
 };
 
-int pre_process(struct tplg_pre_processor *tplg_pp, char *config, size_t config_size);
+int pre_process(struct tplg_pre_processor *tplg_pp, char *config, size_t config_size,
+		const char *pre_processor_defs);
 int init_pre_precessor(struct tplg_pre_processor **tplg_pp, snd_output_type_t type,
 		       const char *output_file);
 void free_pre_preprocessor(struct tplg_pre_processor *tplg_pp);


### PR DESCRIPTION
Add a -D switch to be able to pass pre-processor definitions that will
be used to expand arguments in the input config file. This will be
useful to generate multiple topology binaries from the same input config
file with different argument values.

For example: if we had a pipeline config as follows:

Object.Pipeline {
	volume-playback.1 {
		dynamic_pipeline $DYNAMIC_PIPELINE
	}
}

We can define an argument for DYNAMIC_PIPELINE as:

@args [ DYNAMIC_PIPELINE ]
@args.DYNAMIC_PIPELINE {
	type integer
	default 0
}

And when pre-processin the conf file pass "-D DYNAMIC_PIPELINE=1" to enable
dynamic pipeline in the topology.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>