### PR TITLE
Fix for arecord recording ghost data

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -2268,7 +2268,7 @@ static ssize_t pcm_read(u_char *data, size_t rcount)
 		}
 	}
 abort:
-	return rcount;
+	return result;
 }
 
 static ssize_t pcm_readv(u_char **data, unsigned int channels, size_t rcount)
@@ -3326,7 +3326,7 @@ static void capture(char *orig_name)
 			}
 			count -= c;
 			rest -= c;
-			fdcount += c;
+			fdcount += save;
 		}
 
 		/* re-enable SIGUSR1 signal */


### PR DESCRIPTION
We noticed the issue in our tests, when using arecord would produce files with glitches at recording end.

Apparently it was caused by writing full buffer to output file instead of the data read, when stopping recording.
Following commit adjust the code to only write the amount of data that was read and making sure that file size matches internal format data.
