### PR TITLE
axfer: fix typo in manual

### DIFF
--- a/axfer/axfer-transfer.1
+++ b/axfer/axfer-transfer.1
@@ -591,7 +591,7 @@ will close handled files and PCM substream to be going to finish run time.
 will suspend PCM substream and
 .I SIGCONT
 will resume it. No XRUNs are expected. With libffado backend, the suspend/resume
-is not supported and runtime is aboeted immediately.
+is not supported and runtime is aborted immediately.
 
 The other signals perform default behaviours.
 


### PR DESCRIPTION
The spelling of 'aborted' was 'aboeted' in the manual. This commit fixes
it.

Fixes: a37703614a90 ("axfer: fulfill manual section for libffado backend")
Reported-by: Chao Song chao.song@linux.intel.com
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>