### PR TITLE
amidi: restore space between bytes

### DIFF
--- a/amidi/amidi.c
+++ b/amidi/amidi.c
@@ -433,14 +433,12 @@ static void print_byte(unsigned char byte, struct timespec *ts)
 			fputs("\n  ", stdout);
 	}
 
-	if (newline) {
-		printf("\n");
-
+	putchar(newline ? '\n' : ' ');
+	if (newline && do_print_timestamp) {
 		/* Nanoseconds does not make a lot of sense for serial MIDI (the
 		 * 31250 bps one) but I'm not sure about MIDI over USB.
 		 */
-		if (do_print_timestamp)
-			printf("%lld.%.9ld) ", (long long)ts->tv_sec, ts->tv_nsec);
+		printf("%lld.%.9ld) ", (long long)ts->tv_sec, ts->tv_nsec);
 	}
 
 	printf("%02X", byte);


### PR DESCRIPTION
Commit 9a8fcec ("amidi: add timestamp option for dump") removed the
space between bytes when dumping MIDI, changing the output from:

	90 45 40
	80 45 00

to:

	904540
	804500

It seems that this was an unintentional side effect of refactoring the
code to add the new timestamp output but the result is less readable
than it was before.

Restore the space between bytes in the same message.

Fixes: 9a8fcec ("amidi: add timestamp option for dump")
Signed-off-by: John Keeping <john@metanate.com>