### PR TITLE
topology: plugins: fix off by 1 mem allocation error

### DIFF
--- a/topology/nhlt/nhlt-processor.c
+++ b/topology/nhlt/nhlt-processor.c
@@ -96,7 +96,7 @@ static int print_as_hex_bytes(uint8_t *manifest_buffer, uint32_t manifest_size,
 	char *dst;
 	int i;
 
-	bytes_string_buffer = calloc((manifest_size + nhlt_size) * ALSA_BYTE_CHARS,
+	bytes_string_buffer = calloc((manifest_size + nhlt_size) * ALSA_BYTE_CHARS + 1,
 				     sizeof(uint8_t));
 	if (!bytes_string_buffer)
 		return -ENOMEM;


### PR DESCRIPTION
Fix valgrind memcheck error:

==1337389== Invalid write of size 1
==1337389==    at 0x4A4AFAB: __vsnprintf_internal (vsnprintf.c:117)
==1337389==    by 0x4AECF40: __snprintf_chk (snprintf_chk.c:38)
==1337389==    by 0x484B870: snprintf (stdio2.h:67)
==1337389==    by 0x484B870: print_as_hex_bytes (nhlt-processor.c:112)
==1337389==    by 0x484B870: merge_manifest_data (nhlt-processor.c:154)
==1337389==    by 0x484B870: do_nhlt (nhlt-processor.c:420)
==1337389==    by 0x484B870: _snd_topology_nhlt_process (nhlt-processor.c:484)

The consecutive snprintf overwrites always the previous terminator until
it hits the very last call of:

snprintf(dst, ALSA_BYTE_CHARS + 1, "0x%02x,", *nhlt_buffer);

when the size n given to snprintf is 1 more than allocated.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>