### PR TITLE
configure.ac: fix build without dlfcn.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,9 @@ AC_CHECK_FUNC([snd_ctl_elem_add_enumerated],
 	      , [AC_ERROR([No user enum control support in alsa-lib])])
 fi
 
+
+AC_CHECK_HEADERS([dlfcn.h])
+
 dnl Check components
 AC_CHECK_HEADERS([alsa/pcm.h], [have_pcm="yes"], [have_pcm="no"],
   [#include <alsa/asoundlib.h>])
@@ -74,7 +77,7 @@ AM_CONDITIONAL(HAVE_MIXER, test "$have_mixer" = "yes")
 AM_CONDITIONAL(HAVE_RAWMIDI, test "$have_rawmidi" = "yes")
 AM_CONDITIONAL(HAVE_SEQ, test "$have_seq" = "yes")
 AM_CONDITIONAL(HAVE_UCM, test "$have_ucm" = "yes")
-AM_CONDITIONAL(HAVE_TOPOLOGY, test "$have_topology" = "yes")
+AM_CONDITIONAL(HAVE_TOPOLOGY, test "$have_topology" = "yes" -a "$ac_cv_header_dlfcn_h" = "yes")
 AM_CONDITIONAL(HAVE_SAMPLERATE, test "$have_samplerate" = "yes")
 AM_CONDITIONAL(HAVE_FFADO, test "$have_ffado" = "yes")
 


### PR DESCRIPTION
Fix the following static build failure (i.e. without `dlfcn.h`) raised since version 1.2.7 and https://github.com/alsa-project/alsa-utils/commit/44d3e8aa44fc12f95bfeef0e3a1051e8f77047b5:

```
pre-processor.c:28:10: fatal error: dlfcn.h: No such file or directory
   28 | #include <dlfcn.h>
      |          ^~~~~~~~~

```
Fixes:
 - http://autobuild.buildroot.org/results/1173a1ee28a58ce565a3274f35e868c35bb2e04e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>