### PR TITLE
bat: Add 'readcapture' option to support analyzing external audio

### DIFF
--- a/bat/common.h
+++ b/bat/common.h
@@ -25,6 +25,7 @@
 #define OPT_ROUNDTRIPLATENCY		(OPT_BASE + 6)
 #define OPT_SNRTHD_DB			(OPT_BASE + 7)
 #define OPT_SNRTHD_PC			(OPT_BASE + 8)
+#define OPT_READCAPTURE			(OPT_BASE + 9)
 
 #define COMPOSE(a, b, c, d)		((a) | ((b)<<8) | ((c)<<16) | ((d)<<24))
 #define WAV_RIFF			COMPOSE('R', 'I', 'F', 'F')
@@ -151,6 +152,7 @@ enum _bat_op_mode {
 	MODE_UNKNOWN = -1,
 	MODE_SINGLE = 0,
 	MODE_LOOPBACK,
+	MODE_ANALYZE_ONLY,
 	MODE_LAST
 };
 
@@ -223,6 +225,7 @@ struct bat {
 	char *narg;			/* argument string of duration */
 	char *logarg;			/* path name of log file */
 	char *debugplay;		/* path name to store playback signal */
+	char *capturefile;		/* path name for previously saved recording */
 	bool standalone;		/* enable to bypass analysis */
 	bool roundtriplatency;		/* enable round trip latency */
 


### PR DESCRIPTION
If audio data is captured on another device (ie we are NOT using
loopback mode), then allow alsabat to analyze that data, by passing
a filename reference on the command line.

Add the '--readcapture' option to the argument parser. When
this option is specified, avoid doing a local capture, and instead
just read the audio data from the indicated file, and analyze that.

Signed-off-by: Tim Bird <tim.bird@sony.com>