### PR TITLE
Change to RemainAfterExit=yes in alsa-restore.service.in

### DIFF
--- a/alsactl/alsa-restore.service.in
+++ b/alsactl/alsa-restore.service.in
@@ -10,6 +10,6 @@ ConditionPathExistsGlob=/dev/snd/control*
 
 [Service]
 Type=oneshot
-RemainAfterExit=true
+RemainAfterExit=yes
 ExecStart=-@sbindir@/alsactl restore
 ExecStop=-@sbindir@/alsactl store


### PR DESCRIPTION
Fresh Manjaro installation.
Default volume value was 75%, no matter to what value I change it, it resets to 75% on reboot/shutdown.

After changing to `RemainAfterExit=yes` from `RemainAfterExit=true` in `alsa-restore.service`, the volume value is properly saved and restored on reboot/shutdown. I did check the following [link](https://www.freedesktop.org/software/systemd/man/systemd.service.html) and it says:

> RemainAfterExit=
> Takes a boolean value that specifies whether the service shall be considered active even when all its processes exited. Defaults to no.

But if you look at `Example 4. Stoppable oneshot service`, it clearly sets `RemainAfterExit=yes` with `Type=oneshot`.