### PR TITLE
topology: propagate nhlt plugin error to main program

### DIFF
--- a/topology/nhlt/intel/ssp/ssp-process.c
+++ b/topology/nhlt/intel/ssp/ssp-process.c
@@ -523,7 +523,8 @@ int ssp_calculate(struct intel_nhlt_params *nhlt)
 
 	/* calculate blob for every hw config */
 	for (i = 0; i < ssp->ssp_hw_config_count[ssp->ssp_count]; i++)
-		ssp_calculate_intern(nhlt, i);
+		if (ssp_calculate_intern(nhlt, i) < 0)
+			return -EINVAL;
 
 	ssp->ssp_count++;
 

--- a/topology/pre-processor.c
+++ b/topology/pre-processor.c
@@ -98,7 +98,7 @@ static int run_plugin(struct tplg_pre_processor *tplg_pp, char *plugin)
 	}
 
 	/* process plugin */
-	process(tplg_pp->input_cfg, tplg_pp->output_cfg);
+	ret = process(tplg_pp->input_cfg, tplg_pp->output_cfg);
 
 err:
 	if (h)
@@ -689,7 +689,7 @@ int pre_process(struct tplg_pre_processor *tplg_pp, char *config, size_t config_
 	/* process topology plugins */
 	err = pre_process_plugins(tplg_pp);
 	if (err < 0) {
-		fprintf(stderr, "Unable to run pre-process plugins\n");
+		fprintf(stderr, "Unable to run pre-process plugins or plugins return error\n");
 		goto err;
 	}
 


### PR DESCRIPTION
Let's propagate nhlt plugin error to main program, so that we don't generate a wrong nhlt blob silently.

Signed-off-by: Chao Song <chao.song@linux.intel.com>