### PR TITLE
aplay,axfer: Replace off64_t with off_t

### DIFF
--- a/axfer/container-voc.c
+++ b/axfer/container-voc.c
@@ -775,7 +775,7 @@ static int write_block_terminator(struct container_context *cntr)
 static int write_data_size(struct container_context *cntr, uint64_t byte_count)
 {
 	struct builder_state *state = cntr->private_data;
-	off64_t offset;
+	off_t offset;
 	uint8_t size_field[3];
 	int err;
 

--- a/axfer/container.c
+++ b/axfer/container.c
@@ -113,11 +113,11 @@ enum container_format container_format_from_path(const char *path)
 	return CONTAINER_FORMAT_RAW;
 }
 
-int container_seek_offset(struct container_context *cntr, off64_t offset)
+int container_seek_offset(struct container_context *cntr, off_t offset)
 {
-	off64_t pos;
+	off_t pos;
 
-	pos = lseek64(cntr->fd, offset, SEEK_SET);
+	pos = lseek(cntr->fd, offset, SEEK_SET);
 	if (pos < 0)
 		return -errno;
 	if (pos != offset)

--- a/axfer/container.h
+++ b/axfer/container.h
@@ -107,7 +107,7 @@ int container_recursive_read(struct container_context *cntr, void *buf,
 			     unsigned int byte_count);
 int container_recursive_write(struct container_context *cntr, void *buf,
 			      unsigned int byte_count);
-int container_seek_offset(struct container_context *cntr, off64_t offset);
+int container_seek_offset(struct container_context *cntr, off_t offset);
 
 extern const struct container_parser container_parser_riff_wave;
 extern const struct container_builder container_builder_riff_wave;

--- a/axfer/test/container-test.c
+++ b/axfer/test/container-test.c
@@ -153,7 +153,7 @@ static int callback(struct test_generator *gen, snd_pcm_access_t access,
 
 	for (i = 0; i < ARRAY_SIZE(entries); ++i) {
 		int fd;
-		off64_t pos;
+		off_t pos;
 
 		frames_per_second = entries[i];
 
@@ -172,7 +172,7 @@ static int callback(struct test_generator *gen, snd_pcm_access_t access,
 			     frames_per_second, frame_buffer, frame_count,
 			     trial->verbose);
 
-		pos = lseek64(fd, 0, SEEK_SET);
+		pos = lseek(fd, 0, SEEK_SET);
 		if (pos < 0) {
 			err = -errno;
 			break;

--- a/axfer/test/mapper-test.c
+++ b/axfer/test/mapper-test.c
@@ -257,7 +257,7 @@ static int test_mapper(struct mapper_trial *trial, snd_pcm_access_t access,
 		goto end;
 
 	for (i = 0; i < cntr_count; ++i) {
-		off64_t pos = lseek64(cntr_fds[i], 0, SEEK_SET);
+		off_t pos = lseek(cntr_fds[i], 0, SEEK_SET);
 		if (pos != 0) {
 			err = -EIO;
 			goto end;


### PR DESCRIPTION
Also replace lseek64 with lseek.

_FILE_OFFSET_BITS=64 is passed to needed platforms since configure uses AC_SYS_LARGEFILE macro. Therefore off_t is already 64-bit and lseek is same as lseek64.

Additionally this fixes buils with latest musl where these lfs64 functions are moved out from _GNU_SOURCE and under _LARGEFILE64_SOURCE macro alone. This makes the builds fail on 32-bit platforms even though default off_t on musl is 64-bit always.

Signed-off-by: Khem Raj <raj.khem@gmail.com>