### PR TITLE
topology: pre-processor: fix regular expression flags

### DIFF
--- a/topology/pre-processor.c
+++ b/topology/pre-processor.c
@@ -493,14 +493,14 @@ static int pre_process_include_conf(struct tplg_pre_processor *tplg_pp, snd_conf
 		if (snd_config_get_id(n, &id) < 0)
 			continue;
 
-		ret = regcomp(&regex, id, 0);
+		ret = regcomp(&regex, id, REG_EXTENDED | REG_ICASE);
 		if (ret) {
 			fprintf(stderr, "Could not compile regex\n");
 			goto err;
 		}
 
 		/* Execute regular expression */
-		ret = regexec(&regex, value, 0, NULL, REG_ICASE);
+		ret = regexec(&regex, value, 0, NULL, 0);
 		if (ret)
 			continue;
 


### PR DESCRIPTION
The REG_ICASE flag is a compile-time flag (cflags), it should be used with regcomp() instead of regexec(). Also add the REG_EXTENDED flag in this patch to make patterns like 'tgl|adl' work.