### PR TITLE
alsactl: add fallback for loading driver state

### DIFF
--- a/alsactl/90-alsa-restore.rules.in
+++ b/alsactl/90-alsa-restore.rules.in
@@ -2,6 +2,8 @@ ACTION=="add", SUBSYSTEM=="sound", KERNEL=="controlC*", KERNELS!="card*", TEST==
 GOTO="alsa_restore_end"
 
 LABEL="alsa_restore_go"
+TEST!="@asoundrcfile@", TEST=="@initasoundrcfile@", TEST=="@daemonswitch@", RUN+="@sbindir@/alsactl -f @initasoundrcfile@ nrestore $attr{device/number}", GOTO="alsa_restore_end"
+TEST!="@asoundrcfile@", TEST=="@initasoundrcfile@", TEST!="@daemonswitch@", RUN+="@sbindir@/alsactl -f @initasoundrcfile@ restore $attr{device/number}", GOTO="alsa_restore_end"
 TEST!="@daemonswitch@", RUN+="@sbindir@/alsactl restore $attr{device/number}"
 TEST=="@daemonswitch@", RUN+="@sbindir@/alsactl nrestore $attr{device/number}"
 

--- a/alsactl/Makefile.am
+++ b/alsactl/Makefile.am
@@ -45,6 +45,7 @@ edit = \
 		  -e 's,@mydatadir\@,$(mydatadir),g' \
 		  -e 's,@daemonswitch\@,$(ALSACTL_DAEMONSWITCH),g' \
 		  -e 's,@asoundrcfile\@,$(ASOUND_STATE_DIR)/asound.state,g' \
+		  -e 's,@initasoundrcfile\@,$(INIT_ASOUND_STATE_DIR)/asound.state,g' \
 							< $< > $@ || rm $@
 
 alsa-state.service: alsa-state.service.in

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,12 @@ AC_ARG_WITH([asound-state-dir],
         [ASOUND_STATE_DIR="/var/lib/alsa"])
 AC_SUBST(ASOUND_STATE_DIR)
 
+AC_ARG_WITH([init-asound-state-dir],
+        AS_HELP_STRING([--with-init-asound-state-dir=DIR], [Directory to place an initial asound.state file in]),
+        [INIT_ASOUND_STATE_DIR="$withval"],
+        [INIT_ASOUND_STATE_DIR="/usr/lib/alsa"])
+AC_SUBST(INIT_ASOUND_STATE_DIR)
+
 AC_ARG_WITH([alsactl-lock-dir],
         AS_HELP_STRING([--with-alsactl-lock-dir=DIR], [Directory to place lock files in]),
         [ASOUND_LOCK_DIR="$withval"],


### PR DESCRIPTION
Support loading driver state from the vendor-specific pre-installed sound configuration file /usr/lib/alsa/asound.state.

This commit unblocks changes in the `alsa-state` yocto recipe to install `asound.state` into `/usr/lib/alsa/`. This is a good move to support ostree distros and to keep an initial `asound.state` in a safe place.