### PR TITLE
arecord: duration incorrect when ALSA chooses different sample rate

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -3224,6 +3224,9 @@ static void capture(char *orig_name)
 	off_t count, rest;		/* number of bytes to capture */
 	struct stat statbuf;
 
+	/* setup sound hardware */
+	set_params();
+
 	/* get number of bytes to capture */
 	count = calc_count();
 	if (count == 0)
@@ -3241,9 +3244,6 @@ static void capture(char *orig_name)
 
 	/* display verbose output to console */
 	header(file_type, name);
-
-	/* setup sound hardware */
-	set_params();
 
 	/* write to stdout? */
 	if (!name || !strcmp(name, "-")) {


### PR DESCRIPTION
I encountered this issue whilst researching a bug in capture handling in ALSA/PulseAudio/PortAudio/Audacity. When recording for    a fixed duration the duration is measured by the quantity of samples, not clock time. In `capture()`  a call to `calc_count()` occurs before `set_params()`, but in that latter function the actual sample rate used may differ from the requested rate   , but the count is not recalculated. E.g:
```
$ time arecord -D hw:1,0 -d 2 -c 2 -f S16_LE -r 384000 --dump-hw-params /tmp/test.11.wav
Recording WAVE '/tmp/test.11.wav' : Signed 16 bit Little Endian, Rate 384000 Hz, Stereo
HW Params of device "hw:1,0":
--------------------
ACCESS:  MMAP_INTERLEAVED RW_INTERLEAVED
FORMAT:  S16_LE S32_LE
SUBFORMAT:  STD
SAMPLE_BITS: [16 32]
FRAME_BITS: [32 64]
CHANNELS: 2
RATE: [44100 192000]
PERIOD_TIME: (83 11888617)
PERIOD_SIZE: [16 524288]
PERIOD_BYTES: [128 2097152]
PERIODS: [2 32]
BUFFER_TIME: (166 23777234)
BUFFER_SIZE: [32 1048576]
BUFFER_BYTES: [128 4194304]
TICK_TIME: ALL
--------------------
Warning: rate is not accurate (requested = 384000Hz, got = 192000Hz)
         please, try the plug plugin

real    0m4.009s
user    0m0.004s
sys     0m0.007s
```
In this example, because the actual sample rate was 1/2 of that requested, count is double what it should be and therefore the    recording continues for 4 seconds instead of the requested 2 seconds.
Moving the call to `set_params()` to before the count logic solves it:
```
$  time aplay/aplay -C -D hw:1,0 -d 2 -c 2 -f S16_LE -r 384000 --dump-hw-params /tmp/test.11.wav
HW Params of device "hw:1,0":
--------------------
ACCESS:  MMAP_INTERLEAVED RW_INTERLEAVED
FORMAT:  S16_LE S32_LE
SUBFORMAT:  STD
SAMPLE_BITS: [16 32]
FRAME_BITS: [32 64]
CHANNELS: 2
RATE: [44100 192000]
PERIOD_TIME: (83 11888617)
PERIOD_SIZE: [16 524288]
PERIOD_BYTES: [128 2097152]
PERIODS: [2 32]
BUFFER_TIME: (166 23777234)
BUFFER_SIZE: [32 1048576]
BUFFER_BYTES: [128 4194304]
TICK_TIME: ALL
--------------------
Warning: rate is not accurate (requested = 384000Hz, got = 192000Hz)
         please, try the plug plugin
Recording WAVE '/tmp/test.11.wav' : Signed 16 bit Little Endian, Rate 192000 Hz, Stereo

real    0m2.009s
user    0m0.001s
sys     0m0.008s
```
