### PR TITLE
Update `test` '-a' and '-o' to '&&' and '||'

### DIFF
--- a/alsa-info/alsa-info.sh
+++ b/alsa-info/alsa-info.sh
@@ -42,12 +42,12 @@ REQUIRES="mktemp grep pgrep awk date uname cat sort dmesg amixer alsactl"
 #
 
 update() {
-	test -z "$WGET" -o ! -x "$WGET" && return
+	test -z "$WGET" || test ! -x "$WGET" && return
 
 	SHFILE=$(mktemp -t alsa-info.XXXXXXXXXX) || exit 1
 	wget -O $SHFILE "https://www.alsa-project.org/alsa-info.sh" >/dev/null 2>&1
 	REMOTE_VERSION=$(grep SCRIPT_VERSION $SHFILE | head -n1 | sed 's/.*=//')
-	if [ -s "$SHFILE" -a "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
+	if [ -s "$SHFILE" ] && [ "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
 		if [[ -n $DIALOG ]]
 		then
 			OVERWRITE=
@@ -100,7 +100,7 @@ update() {
 }
 
 cleanup() {
-	if [ -n "$TEMPDIR" -a "$KEEP_FILES" != "yes" ]; then
+	if [ -n "$TEMPDIR" ] && [ "$KEEP_FILES" != "yes" ]; then
 		rm -rf "$TEMPDIR" 2>/dev/null
 	fi
 	test -n "$KEEP_OUTPUT" || rm -f "$NFILE"


### PR DESCRIPTION
lines 50, 103: in two compound ['s, replace '-a' with '] && ['
  SC2166 – Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well defined. 
  SC2107 – Instead of `[ a && b ]`, use `[ a ] && [ b ]`.

line 45: in a compound test command, change '-o' to '|| test'
  SC1139 – Use `||` instead of `-o` between test commands.
  SC2109 – Instead of `[ a || b ]`, use `[ a ] || [ b ]`.

https://www.shellcheck.net/wiki/SC[0-9]{4}