### PR TITLE
alsactl: fix compilation when building in a subdir

### DIFF
--- a/alsactl/Makefile.am
+++ b/alsactl/Makefile.am
@@ -9,6 +9,8 @@ EXTRA_DIST=alsactl.1 alsactl_init.xml
 
 AM_CFLAGS = -D_GNU_SOURCE
 
+AM_CPPFLAGS = -I$(top_srcdir)/include
+
 alsactl_SOURCES=alsactl.c state.c lock.c utils.c init_parse.c init_ucm.c \
 		daemon.c monitor.c clean.c info.c
 


### PR DESCRIPTION
Fixes: 613372d
Fixes: cff2d1c
Fixes: #212

Compile errors when building in a subdir:
```
alsactl/alsactl.c:33:10: fatal error: os_compat.h: No such file or directory
   33 | #include "os_compat.h"
      |          ^~~~~~~~~~~~~
alsactl/lock.c:34:10: fatal error: os_compat.h: No such file or directory
   34 | #include "os_compat.h"
      |          ^~~~~~~~~~~~~
```