### PR TITLE
Updated single and double quotes throughout

### DIFF
--- a/alsa-info/alsa-info.sh
+++ b/alsa-info/alsa-info.sh
@@ -44,17 +44,17 @@ REQUIRES=(mktemp grep pgrep awk date uname cat sort dmesg amixer alsactl)
 update() {
 	test -z "$WGET" || test ! -x "$WGET" && return
 
-	SHFILE=$(mktemp -t alsa-info.XXXXXXXXXX) || exit 1
-	wget -O $SHFILE "https://www.alsa-project.org/alsa-info.sh" >/dev/null 2>&1
-	REMOTE_VERSION=$(grep SCRIPT_VERSION $SHFILE | head -n1 | sed 's/.*=//')
+	SHFILE="$(mktemp -t alsa-info.XXXXXXXXXX)" || exit 1
+	wget -O "$SHFILE" 'https://www.alsa-project.org/alsa-info.sh' >/dev/null 2>&1
+	REMOTE_VERSION="$(grep SCRIPT_VERSION "$SHFILE" | head -n1 | sed 's/.*=//')"
 	if [ -s "$SHFILE" ] && [ "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
-		if [[ -n $DIALOG ]]
+		if [[ -n "$DIALOG" ]]
 		then
 			OVERWRITE=
-			if [ -w $0 ]; then
+			if [ -w "$0" ]; then
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to install it?\nNOTICE: The original file $0 will be overwritten!" 0 0
 				DIALOG_EXIT_CODE=$?
-				if [[ $DIALOG_EXIT_CODE = 0 ]]; then
+				if [[ "$DIALOG_EXIT_CODE" = 0 ]]; then
 				  OVERWRITE=yes
 				fi
 			fi
@@ -62,32 +62,32 @@ update() {
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to download it?" 0 0
 				DIALOG_EXIT_CODE=$?
 			fi
-			if [[ $DIALOG_EXIT_CODE = 0 ]]
+			if [[ "$DIALOG_EXIT_CODE" = 0 ]]
 			then
 				echo "Newer version detected: $REMOTE_VERSION"
 				echo "To view the ChangeLog, please visit $CHANGELOG"
-				if [ "$OVERWRITE" = "yes" ]; then
-					cp $SHFILE $0
+				if [ "$OVERWRITE" = 'yes' ]; then
+					cp "$SHFILE" "$0"
 					echo "ALSA-Info script has been updated to v $REMOTE_VERSION"
 					echo "Please re-run the script"
-					rm $SHFILE 2>/dev/null
+					rm "$SHFILE" 2>/dev/null
 				else
 					echo "ALSA-Info script has been downloaded as $SHFILE."
 					echo "Please re-run the script from new location."
 				fi
 				exit
 			else
-				rm $SHFILE 2>/dev/null
+				rm "$SHFILE" 2>/dev/null
 			fi
 		else
 			echo "Newer version detected: $REMOTE_VERSION"
 			echo "To view the ChangeLog, please visit $CHANGELOG"
-			if [ -w $0 ]; then
+			if [ -w "$0" ]; then
 				echo "The original file $0 will be overwritten!"
 				echo -n "If you do not like to proceed, press Ctrl-C now.." ; read inp
-				cp $SHFILE $0
+				cp "$SHFILE" "$0"
 				echo "ALSA-Info script has been updated. Please re-run it."
-				rm $SHFILE 2>/dev/null
+				rm "$SHFILE" 2>/dev/null
 			else
 				echo "ALSA-Info script has been downloaded $SHFILE."
 				echo "Please, re-run it from new location."
@@ -95,12 +95,12 @@ update() {
 			exit
 		fi
 	else
-		rm $SHFILE 2>/dev/null
+		rm "$SHFILE" 2>/dev/null
 	fi
 }
 
 cleanup() {
-	if [ -n "$TEMPDIR" ] && [ "$KEEP_FILES" != "yes" ]; then
+	if [ -n "$TEMPDIR" ] && [ "$KEEP_FILES" != 'yes' ]; then
 		rm -rf "$TEMPDIR" 2>/dev/null
 	fi
 	test -n "$KEEP_OUTPUT" || rm -f "$NFILE"
@@ -329,8 +329,8 @@ NFILE=""
 
 PASTEBIN=""
 WWWSERVICE='www.alsa-project.org'
-WELCOME=yes
-PROCEED=yes
+WELCOME='yes'
+PROCEED='yes'
 UPLOAD=ask
 REPEAT=""
 while [ -z "$REPEAT" ]; do
@@ -341,7 +341,7 @@ case "$1" in
 		PROCEED=no
 		;;
 	--upload)
-		UPLOAD=yes
+		UPLOAD='yes'
 		WELCOME=no
 		;;
 	--no-upload)
@@ -349,8 +349,8 @@ case "$1" in
 		WELCOME=no
 		;;
 	--pastebin)
-		PASTEBIN=yes
-		WWWSERVICE=pastebin
+		PASTEBIN='yes'
+		WWWSERVICE='pastebin'
 		;;
 	--no-dialog)
 		DIALOG=""
@@ -366,7 +366,7 @@ done
 
 
 #Script header output.
-if [ "$WELCOME" = yes ]; then
+if [ "$WELCOME" = 'yes' ]; then
 greeting_message="\
 
 This script visits the following commands/files to collect diagnostic
@@ -404,7 +404,7 @@ fi
 
 trap cleanup 0
 
-if [ "$PROCEED" = yes ]; then
+if [ "$PROCEED" = 'yes' ]; then
 
 if [ -z "$LSPCI" ]; then
 	if [ -d /sys/bus/pci ]; then
@@ -413,324 +413,324 @@ if [ -z "$LSPCI" ]; then
 fi
 
 # Fetch the info and store in temp files/variables
-TSTAMP=$(LANG=C TZ=UTC date)
-DISTRO=$(grep -ihs "buntu\|SUSE\|Fedora\|PCLinuxOS\|MEPIS\|Mandriva\|Debian\|Damn\|Sabayon\|Slackware\|KNOPPIX\|Gentoo\|Zenwalk\|Mint\|Kubuntu\|FreeBSD\|Puppy\|Freespire\|Vector\|Dreamlinux\|CentOS\|Arch\|Xandros\|Elive\|SLAX\|Red\|BSD\|KANOTIX\|Nexenta\|Foresight\|GeeXboX\|Frugalware\|64\|SystemRescue\|Novell\|Solaris\|BackTrack\|KateOS\|Pardus\|ALT" /etc/{issue,*release,*version})
+TSTAMP="$(LANG=C TZ=UTC date)"
+DISTRO="$(grep -ihs "buntu\|SUSE\|Fedora\|PCLinuxOS\|MEPIS\|Mandriva\|Debian\|Damn\|Sabayon\|Slackware\|KNOPPIX\|Gentoo\|Zenwalk\|Mint\|Kubuntu\|FreeBSD\|Puppy\|Freespire\|Vector\|Dreamlinux\|CentOS\|Arch\|Xandros\|Elive\|SLAX\|Red\|BSD\|KANOTIX\|Nexenta\|Foresight\|GeeXboX\|Frugalware\|64\|SystemRescue\|Novell\|Solaris\|BackTrack\|KateOS\|Pardus\|ALT" /etc/{issue,*release,*version})"
 read -r KERNEL_RELEASE KERNEL_MACHINE KERNEL_PROCESSOR KERNEL_OS < <(uname -rpmo)
 read -r KERNEL_VERSION < <(uname -v)
 if [[ "$KERNEL_VERSION" = *SMP* ]]; then KERNEL_SMP=Yes; else KERNEL_SMP=No; fi
-ALSA_DRIVER_VERSION=$(cat /proc/asound/version | head -n1 | awk '{ print $7 }' | sed 's/\.$//')
+ALSA_DRIVER_VERSION="$(cat /proc/asound/version | head -n1 | awk '{ print $7 }' | sed 's/\.$//')"
 get_alsa_library_version
-ALSA_UTILS_VERSION=$(amixer -v | awk '{ print $3 }')
+ALSA_UTILS_VERSION="$(amixer -v | awk '{ print $3 }')"
 
-ESDINST=$(command -v esd)
-PWINST=$(command -v pipewire)
-PAINST=$(command -v pulseaudio)
-ARTSINST=$(command -v artsd)
-JACKINST=$(command -v jackd)
-JACK2INST=$(command -v jackdbus)
-ROARINST=$(command -v roard)
-DMIDECODE=$(command -v dmidecode)
+ESDINST="$(command -v esd)"
+PWINST="$(command -v pipewire)"
+PAINST="$(command -v pulseaudio)"
+ARTSINST="$(command -v artsd)"
+JACKINST="$(command -v jackd)"
+JACK2INST="$(command -v jackdbus)"
+ROARINST="$(command -v roard)"
+DMIDECODE="$(command -v dmidecode)"
 
 #Check for DMI data
 if [ -d /sys/class/dmi/id ]; then
     # No root privileges are required when using sysfs method
-    DMI_SYSTEM_MANUFACTURER=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_NAME=$(cat /sys/class/dmi/id/product_name 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_VERSION=$(cat /sys/class/dmi/id/product_version 2>/dev/null)
-    DMI_SYSTEM_FIRMWARE_VERSION=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
-    DMI_SYSTEM_SKU=$(cat /sys/class/dmi/id/product_sku 2>/dev/null)
-    DMI_BOARD_VENDOR=$(cat /sys/class/dmi/id/board_vendor 2>/dev/null)
-    DMI_BOARD_NAME=$(cat /sys/class/dmi/id/board_name 2>/dev/null)
-elif [ -x $DMIDECODE ]; then
-    DMI_SYSTEM_MANUFACTURER=$($DMIDECODE -s system-manufacturer 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_NAME=$($DMIDECODE -s system-product-name 2>/dev/null)
-    DMI_SYSTEM_PRODUCT_VERSION=$($DMIDECODE -s system-version 2>/dev/null)
-    DMI_SYSTEM_FIRMWARE_VERSION=$($DMIDECODE -s bios-version 2>/dev/null)
-    DMI_SYSTEM_SKU=$($DMIDECODE -s system-sku-number 2>/dev/null)
-    DMI_BOARD_VENDOR=$($DMIDECODE -s baseboard-manufacturer 2>/dev/null)
-    DMI_BOARD_NAME=$($DMIDECODE -s baseboard-product-name 2>/dev/null)
+    DMI_SYSTEM_MANUFACTURER="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null)"
+    DMI_SYSTEM_PRODUCT_NAME="$(cat /sys/class/dmi/id/product_name 2>/dev/null)"
+    DMI_SYSTEM_PRODUCT_VERSION="$(cat /sys/class/dmi/id/product_version 2>/dev/null)"
+    DMI_SYSTEM_FIRMWARE_VERSION="$(cat /sys/class/dmi/id/bios_version 2>/dev/null)"
+    DMI_SYSTEM_SKU="$(cat /sys/class/dmi/id/product_sku 2>/dev/null)"
+    DMI_BOARD_VENDOR="$(cat /sys/class/dmi/id/board_vendor 2>/dev/null)"
+    DMI_BOARD_NAME="$(cat /sys/class/dmi/id/board_name 2>/dev/null)"
+elif [ -x "$DMIDECODE" ]; then
+    DMI_SYSTEM_MANUFACTURER="$("$DMIDECODE" -s system-manufacturer 2>/dev/null)"
+    DMI_SYSTEM_PRODUCT_NAME="$("$DMIDECODE" -s system-product-name 2>/dev/null)"
+    DMI_SYSTEM_PRODUCT_VERSION="$("$DMIDECODE" -s system-version 2>/dev/null)"
+    DMI_SYSTEM_FIRMWARE_VERSION="$("$DMIDECODE" -s bios-version 2>/dev/null)"
+    DMI_SYSTEM_SKU="$("$DMIDECODE" -s system-sku-number 2>/dev/null)"
+    DMI_BOARD_VENDOR="$("$DMIDECODE" -s baseboard-manufacturer 2>/dev/null)"
+    DMI_BOARD_NAME="$("$DMIDECODE" -s baseboard-product-name 2>/dev/null)"
 fi
 
 # Check for ACPI device status
 if [ -d /sys/bus/acpi/devices ]; then
     for f in /sys/bus/acpi/devices/*/status; do
-	ACPI_STATUS=$(cat $f 2>/dev/null);
+	ACPI_STATUS="$(cat "$f" 2>/dev/null)"
 	if [[ "$ACPI_STATUS" -ne 0 ]]; then
-	    echo $f $'\t' $ACPI_STATUS >>$TEMPDIR/acpidevicestatus.tmp;
+	    echo "$f" $'\t' "$ACPI_STATUS" >> "$TEMPDIR/acpidevicestatus.tmp"
 	fi
     done
 fi
 
-awk '{ print $2 " (card " $1 ")" }' < /proc/asound/modules > $TEMPDIR/alsamodules.tmp 2> /dev/null
-cat /proc/asound/cards > $TEMPDIR/alsacards.tmp
+awk '{ print $2 " (card " $1 ")" }' < /proc/asound/modules > "$TEMPDIR/alsamodules.tmp" 2> /dev/null
+cat /proc/asound/cards > "$TEMPDIR/alsacards.tmp"
 if [[ ! -z "$LSPCI" ]]; then
 	for class in 0401 0402 0403; do
 		lspci -vvnn -d "::$class" | sed -n '/^[^\t]/,+1p'
-	done > $TEMPDIR/lspci.tmp
+	done > "$TEMPDIR/lspci.tmp"
 fi
 
 #Check for HDA-Intel cards codec#*
-cat /proc/asound/card*/codec\#* > $TEMPDIR/alsa-hda-intel.tmp 2> /dev/null
+cat /proc/asound/card*/codec\#* > "$TEMPDIR/alsa-hda-intel.tmp" 2> /dev/null
 
 #Check for AC97 cards codec
-cat /proc/asound/card*/codec97\#0/ac97\#0-0 > $TEMPDIR/alsa-ac97.tmp 2> /dev/null
-cat /proc/asound/card*/codec97\#0/ac97\#0-0+regs > $TEMPDIR/alsa-ac97-regs.tmp 2> /dev/null
+cat /proc/asound/card*/codec97\#0/ac97\#0-0 > "$TEMPDIR/alsa-ac97.tmp" 2> /dev/null
+cat /proc/asound/card*/codec97\#0/ac97\#0-0+regs > "$TEMPDIR/alsa-ac97-regs.tmp" 2> /dev/null
 
 #Check for USB descriptors
 if [ -x /usr/bin/lsusb ]; then
     for f in /proc/asound/card[0-9]*/usbbus; do
 	test -f "$f" || continue
-	id=$(sed 's@/@:@' $f)
-	lsusb -v -s $id >> $TEMPDIR/lsusb.tmp 2> /dev/null
+	id="$(sed 's@/@:@' "$f")"
+	lsusb -v -s "$id" >> "$TEMPDIR/lsusb.tmp" 2> /dev/null
     done
 fi
 
 #Check for USB stream setup
-cat /proc/asound/card*/stream[0-9]* > $TEMPDIR/alsa-usbstream.tmp 2> /dev/null
+cat /proc/asound/card*/stream[0-9]* > "$TEMPDIR/alsa-usbstream.tmp" 2> /dev/null
 
 #Check for USB mixer setup
-cat /proc/asound/card*/usbmixer > $TEMPDIR/alsa-usbmixer.tmp 2> /dev/null
+cat /proc/asound/card*/usbmixer > "$TEMPDIR/alsa-usbmixer.tmp" 2> /dev/null
 
-#Fetch the info, and put it in $FILE in a nice readable format.
-if [[ -z $PASTEBIN ]]; then
-echo "upload=true&script=true&cardinfo=" > $FILE
+#Fetch the info, and put it in FILE in a nice readable format.
+if [[ -z "$PASTEBIN" ]]; then
+echo "upload=true&script=true&cardinfo=" > "$FILE"
 else
-echo "name=$USER&type=33&description=/tmp/alsa-info.txt&expiry=&s=Submit+Post&content=" > $FILE
+echo "name=$USER&type=33&description=/tmp/alsa-info.txt&expiry=&s=Submit+Post&content=" > "$FILE"
 fi
-echo "!!################################" >> $FILE
-echo "!!ALSA Information Script v $SCRIPT_VERSION" >> $FILE
-echo "!!################################" >> $FILE
-echo "" >> $FILE
-echo "!!Script ran on: $TSTAMP" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Linux Distribution" >> $FILE
-echo "!!------------------" >> $FILE
-echo "" >> $FILE
-echo $DISTRO >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!DMI Information" >> $FILE
-echo "!!---------------" >> $FILE
-echo "" >> $FILE
-echo "Manufacturer:      $DMI_SYSTEM_MANUFACTURER" >> $FILE
-echo "Product Name:      $DMI_SYSTEM_PRODUCT_NAME" >> $FILE
-echo "Product Version:   $DMI_SYSTEM_PRODUCT_VERSION" >> $FILE
-echo "Firmware Version:  $DMI_SYSTEM_FIRMWARE_VERSION" >> $FILE
-echo "System SKU:        $DMI_SYSTEM_SKU" >> $FILE
-echo "Board Vendor:      $DMI_BOARD_VENDOR" >> $FILE
-echo "Board Name:        $DMI_BOARD_NAME" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!ACPI Device Status Information" >> $FILE
-echo "!!---------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/acpidevicestatus.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Kernel Information" >> $FILE
-echo "!!------------------" >> $FILE
-echo "" >> $FILE
-echo "Kernel release:    $KERNEL_VERSION" >> $FILE
-echo "Operating System:  $KERNEL_OS" >> $FILE
-echo "Architecture:      $KERNEL_MACHINE" >> $FILE
-echo "Processor:         $KERNEL_PROCESSOR" >> $FILE
-echo "SMP Enabled:       $KERNEL_SMP" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!ALSA Version" >> $FILE
-echo "!!------------" >> $FILE
-echo "" >> $FILE
-echo "Driver version:     $ALSA_DRIVER_VERSION" >> $FILE
-echo "Library version:    $ALSA_LIB_VERSION" >> $FILE
-echo "Utilities version:  $ALSA_UTILS_VERSION" >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Loaded ALSA modules" >> $FILE
-echo "!!-------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/alsamodules.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
-echo "!!Sound Servers on this system" >> $FILE
-echo "!!----------------------------" >> $FILE
-echo "" >> $FILE
-if [[ -n $PWINST ]];then
-[[ $(pgrep '^(.*/)?pipewire$') ]] && PWRUNNING="Yes" || PWRUNNING="No"
-echo "PipeWire:" >> $FILE
-echo "      Installed - Yes ($PWINST)" >> $FILE
-echo "      Running - $PWRUNNING" >> $FILE
-echo "" >> $FILE
+echo "!!################################" >> "$FILE"
+echo "!!ALSA Information Script v $SCRIPT_VERSION" >> "$FILE"
+echo "!!################################" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!Script ran on: $TSTAMP" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!Linux Distribution" >> "$FILE"
+echo "!!------------------" >> "$FILE"
+echo "" >> "$FILE"
+echo "$DISTRO" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!DMI Information" >> "$FILE"
+echo "!!---------------" >> "$FILE"
+echo "" >> "$FILE"
+echo "Manufacturer:      $DMI_SYSTEM_MANUFACTURER" >> "$FILE"
+echo "Product Name:      $DMI_SYSTEM_PRODUCT_NAME" >> "$FILE"
+echo "Product Version:   $DMI_SYSTEM_PRODUCT_VERSION" >> "$FILE"
+echo "Firmware Version:  $DMI_SYSTEM_FIRMWARE_VERSION" >> "$FILE"
+echo "System SKU:        $DMI_SYSTEM_SKU" >> "$FILE"
+echo "Board Vendor:      $DMI_BOARD_VENDOR" >> "$FILE"
+echo "Board Name:        $DMI_BOARD_NAME" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!ACPI Device Status Information" >> "$FILE"
+echo "!!---------------" >> "$FILE"
+echo "" >> "$FILE"
+cat "$TEMPDIR/acpidevicestatus.tmp" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!Kernel Information" >> "$FILE"
+echo "!!------------------" >> "$FILE"
+echo "" >> "$FILE"
+echo "Kernel release:    $KERNEL_VERSION" >> "$FILE"
+echo "Operating System:  $KERNEL_OS" >> "$FILE"
+echo "Architecture:      $KERNEL_MACHINE" >> "$FILE"
+echo "Processor:         $KERNEL_PROCESSOR" >> "$FILE"
+echo "SMP Enabled:       $KERNEL_SMP" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!ALSA Version" >> "$FILE"
+echo "!!------------" >> "$FILE"
+echo "" >> "$FILE"
+echo "Driver version:     $ALSA_DRIVER_VERSION" >> "$FILE"
+echo "Library version:    $ALSA_LIB_VERSION" >> "$FILE"
+echo "Utilities version:  $ALSA_UTILS_VERSION" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!Loaded ALSA modules" >> "$FILE"
+echo "!!-------------------" >> "$FILE"
+echo "" >> "$FILE"
+cat "$TEMPDIR/alsamodules.tmp" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
+echo "!!Sound Servers on this system" >> "$FILE"
+echo "!!----------------------------" >> "$FILE"
+echo "" >> "$FILE"
+if [[ -n "$PWINST" ]];then
+[[ "$(pgrep '^(.*/)?pipewire$')" ]] && PWRUNNING=Yes || PWRUNNING=No
+echo "PipeWire:" >> "$FILE"
+echo "      Installed - Yes ($PWINST)" >> "$FILE"
+echo "      Running - $PWRUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $PAINST ]];then
-[[ $(pgrep '^(.*/)?pulseaudio$') ]] && PARUNNING="Yes" || PARUNNING="No"
-echo "Pulseaudio:" >> $FILE
-echo "      Installed - Yes ($PAINST)" >> $FILE
-echo "      Running - $PARUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$PAINST" ]];then
+[[ "$(pgrep '^(.*/)?pulseaudio$')" ]] && PARUNNING=Yes || PARUNNING=No
+echo "Pulseaudio:" >> "$FILE"
+echo "      Installed - Yes ($PAINST)" >> "$FILE"
+echo "      Running - $PARUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $ESDINST ]];then
-[[ $(pgrep '^(.*/)?esd$') ]] && ESDRUNNING="Yes" || ESDRUNNING="No"
-echo "ESound Daemon:" >> $FILE
-echo "      Installed - Yes ($ESDINST)" >> $FILE
-echo "      Running - $ESDRUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$ESDINST" ]];then
+[[ "$(pgrep '^(.*/)?esd$')" ]] && ESDRUNNING=Yes || ESDRUNNING=No
+echo "ESound Daemon:" >> "$FILE"
+echo "      Installed - Yes ($ESDINST)" >> "$FILE"
+echo "      Running - $ESDRUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $ARTSINST ]];then
-[[ $(pgrep '^(.*/)?artsd$') ]] && ARTSRUNNING="Yes" || ARTSRUNNING="No"
-echo "aRts:" >> $FILE
-echo "      Installed - Yes ($ARTSINST)" >> $FILE
-echo "      Running - $ARTSRUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$ARTSINST" ]];then
+[[ "$(pgrep '^(.*/)?artsd$')" ]] && ARTSRUNNING=Yes || ARTSRUNNING=No
+echo "aRts:" >> "$FILE"
+echo "      Installed - Yes ($ARTSINST)" >> "$FILE"
+echo "      Running - $ARTSRUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $JACKINST ]];then
-[[ $(pgrep '^(.*/)?jackd$') ]] && JACKRUNNING="Yes" || JACKRUNNING="No"
-echo "Jack:" >> $FILE
-echo "      Installed - Yes ($JACKINST)" >> $FILE
-echo "      Running - $JACKRUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$JACKINST" ]];then
+[[ "$(pgrep '^(.*/)?jackd$')" ]] && JACKRUNNING=Yes || JACKRUNNING=No
+echo "Jack:" >> "$FILE"
+echo "      Installed - Yes ($JACKINST)" >> "$FILE"
+echo "      Running - $JACKRUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $JACK2INST ]];then
-[[ $(pgrep '^(.*/)?jackdbus$') ]] && JACK2RUNNING="Yes" || JACK2RUNNING="No"
-echo "Jack2:" >> $FILE
-echo "      Installed - Yes ($JACK2INST)" >> $FILE
-echo "      Running - $JACK2RUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$JACK2INST" ]];then
+[[ "$(pgrep '^(.*/)?jackdbus$')" ]] && JACK2RUNNING=Yes || JACK2RUNNING=No
+echo "Jack2:" >> "$FILE"
+echo "      Installed - Yes ($JACK2INST)" >> "$FILE"
+echo "      Running - $JACK2RUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
-if [[ -n $ROARINST ]];then
-[[ $(pgrep '^(.*/)?roard$') ]] && ROARRUNNING="Yes" || ROARRUNNING="No"
-echo "RoarAudio:" >> $FILE
-echo "      Installed - Yes ($ROARINST)" >> $FILE
-echo "      Running - $ROARRUNNING" >> $FILE
-echo "" >> $FILE
+if [[ -n "$ROARINST" ]];then
+[[ "$(pgrep '^(.*/)?roard$')" ]] && ROARRUNNING=Yes || ROARRUNNING=No
+echo "RoarAudio:" >> "$FILE"
+echo "      Installed - Yes ($ROARINST)" >> "$FILE"
+echo "      Running - $ROARRUNNING" >> "$FILE"
+echo "" >> "$FILE"
 fi
 if [[ -z "$PAINST" && -z "$ESDINST" && -z "$ARTSINST" && -z "$JACKINST" && -z "$ROARINST" ]];then
-echo "No sound servers found." >> $FILE
-echo "" >> $FILE
+echo "No sound servers found." >> "$FILE"
+echo "" >> "$FILE"
 fi
-echo "" >> $FILE
-echo "!!Soundcards recognised by ALSA" >> $FILE
-echo "!!-----------------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/alsacards.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
+echo "" >> "$FILE"
+echo "!!Soundcards recognised by ALSA" >> "$FILE"
+echo "!!-----------------------------" >> "$FILE"
+echo "" >> "$FILE"
+cat "$TEMPDIR/alsacards.tmp" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
 
 if [[ ! -z "$LSPCI" ]]; then
-echo "!!PCI Soundcards installed in the system" >> $FILE
-echo "!!--------------------------------------" >> $FILE
-echo "" >> $FILE
-cat $TEMPDIR/lspci.tmp >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
+echo "!!PCI Soundcards installed in the system" >> "$FILE"
+echo "!!--------------------------------------" >> "$FILE"
+echo "" >> "$FILE"
+cat "$TEMPDIR/lspci.tmp" >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
 fi
 
 if [ "$SNDOPTIONS" ]; then
-echo "!!Modprobe options (Sound related)" >> $FILE
-echo "!!--------------------------------" >> $FILE
-echo "" >> $FILE
-modprobe -c|sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p' >> $FILE
-echo "" >> $FILE
-echo "" >> $FILE
+echo "!!Modprobe options (Sound related)" >> "$FILE"
+echo "!!--------------------------------" >> "$FILE"
+echo "" >> "$FILE"
+modprobe -c|sed -n 's/^options \(snd[-_][^ ]*\)/\1:/p' >> "$FILE"
+echo "" >> "$FILE"
+echo "" >> "$FILE"
 fi
 
 if [ -d "$SYSFS" ]; then
-	echo "!!Loaded sound module options" >> $FILE
-	echo "!!---------------------------" >> $FILE
-	echo "" >> $FILE
+	echo "!!Loaded sound module options" >> "$FILE"
+	echo "!!---------------------------" >> "$FILE"
+	echo "" >> "$FILE"
 	for mod in $(cat /proc/asound/modules | awk '{ print $2 }'); do
-		echo "!!Module: $mod" >> $FILE
+		echo "!!Module: $mod" >> "$FILE"
 		for params in $(echo $SYSFS/module/$mod/parameters/*); do
 			echo -ne "\t"
-			value=$(cat $params)
+			value="$(cat "$params")"
 			echo "$params : $value" | sed 's:.*/::'
-		done >> $FILE
-		echo "" >> $FILE
+		done >> "$FILE"
+		echo "" >> "$FILE"
 	done
-	echo "" >> $FILE
-	echo "!!Sysfs card info" >> $FILE
-	echo "!!---------------" >> $FILE
-	echo "" >> $FILE
+	echo "" >> "$FILE"
+	echo "!!Sysfs card info" >> "$FILE"
+	echo "!!---------------" >> "$FILE"
+	echo "" >> "$FILE"
 	for cdir in $(echo $SYSFS/class/sound/card*); do
-		echo "!!Card: $cdir" >> $FILE
-		driver=$(readlink -f "$cdir/device/driver")
-		echo "Driver: $driver" >> $FILE
-		echo "Tree:" >> $FILE
-		tree --noreport $cdir -L 2 | sed -e 's/^/\t/g' >> $FILE
-		echo "" >> $FILE
+		echo "!!Card: $cdir" >> "$FILE"
+		driver="$(readlink -f "$cdir/device/driver")"
+		echo "Driver: $driver" >> "$FILE"
+		echo "Tree:" >> "$FILE"
+		tree --noreport "$cdir" -L 2 | sed -e 's/^/\t/g' >> "$FILE"
+		echo "" >> "$FILE"
 	done
-	echo "" >> $FILE
-	if [ -d $SYSFS/class/sound/ctl-led ]; then
-		echo "!!Sysfs ctl-led info" >> $FILE
-		echo "!!---------------" >> $FILE
-		echo "" >> $FILE
+	echo "" >> "$FILE"
+	if [ -d "$SYSFS/class/sound/ctl-led" ]; then
+		echo "!!Sysfs ctl-led info" >> "$FILE"
+		echo "!!---------------" >> "$FILE"
+		echo "" >> "$FILE"
 		for path in $(echo $SYSFS/class/sound/ctl-led/[ms][ip]*/card*); do
-			echo "!!CTL-LED: $path" >> $FILE
+			echo "!!CTL-LED: $path" >> "$FILE"
 			if [ -r "$path/list" ]; then
-				list=$(cat "$path/list")
-				echo "List: $list" >> $FILE
+				list="$(cat "$path/list")"
+				echo "List: $list" >> "$FILE"
 			fi
-			#echo "Tree:" >> $FILE
-			#tree --noreport $path -L 2 | sed -e 's/^/\t/g' >> $FILE
-			echo "" >> $FILE
+			#echo "Tree:" >> "$FILE"
+			#tree --noreport $path -L 2 | sed -e 's/^/\t/g' >> "$FILE"
+			echo "" >> "$FILE"
 		done
 	fi
 fi
 
 if [ -s "$TEMPDIR/alsa-hda-intel.tmp" ]; then
-	echo "!!HDA-Intel Codec information" >> $FILE
-	echo "!!---------------------------" >> $FILE
-	echo "--startcollapse--" >> $FILE
-	echo "" >> $FILE
-	cat $TEMPDIR/alsa-hda-intel.tmp >> $FILE
-	echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
+	echo "!!HDA-Intel Codec information" >> "$FILE"
+	echo "!!---------------------------" >> "$FILE"
+	echo "--startcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	cat "$TEMPDIR/alsa-hda-intel.tmp" >> "$FILE"
+	echo "--endcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	echo "" >> "$FILE"
 fi
 
 if [ -s "$TEMPDIR/alsa-ac97.tmp" ]; then
-        echo "!!AC97 Codec information" >> $FILE
-        echo "!!----------------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-ac97.tmp >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-ac97-regs.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
+        echo "!!AC97 Codec information" >> "$FILE"
+        echo "!!----------------------" >> "$FILE"
+        echo "--startcollapse--" >> "$FILE"
+        echo "" >> "$FILE"
+        cat "$TEMPDIR/alsa-ac97.tmp" >> "$FILE"
+        echo "" >> "$FILE"
+        cat "$TEMPDIR/alsa-ac97-regs.tmp" >> "$FILE"
+        echo "--endcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	echo "" >> "$FILE"
 fi
 
 if [ -s "$TEMPDIR/lsusb.tmp" ]; then
-        echo "!!USB Descriptors" >> $FILE
-        echo "!!---------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        cat $TEMPDIR/lsusb.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
+        echo "!!USB Descriptors" >> "$FILE"
+        echo "!!---------------" >> "$FILE"
+        echo "--startcollapse--" >> "$FILE"
+        cat "$TEMPDIR/lsusb.tmp" >> "$FILE"
+        echo "--endcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	echo "" >> "$FILE"
 fi
 
 if [ -s "$TEMPDIR/alsa-usbstream.tmp" ]; then
-        echo "!!USB Stream information" >> $FILE
-        echo "!!----------------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-usbstream.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
+        echo "!!USB Stream information" >> "$FILE"
+        echo "!!----------------------" >> "$FILE"
+        echo "--startcollapse--" >> "$FILE"
+        echo "" >> "$FILE"
+        cat "$TEMPDIR/alsa-usbstream.tmp" >> "$FILE"
+        echo "--endcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	echo "" >> "$FILE"
 fi
 
 if [ -s "$TEMPDIR/alsa-usbmixer.tmp" ]; then
-        echo "!!USB Mixer information" >> $FILE
-        echo "!!---------------------" >> $FILE
-        echo "--startcollapse--" >> $FILE
-        echo "" >> $FILE
-        cat $TEMPDIR/alsa-usbmixer.tmp >> $FILE
-        echo "--endcollapse--" >> $FILE
-	echo "" >> $FILE
-	echo "" >> $FILE
+        echo "!!USB Mixer information" >> "$FILE"
+        echo "!!---------------------" >> "$FILE"
+        echo "--startcollapse--" >> "$FILE"
+        echo "" >> "$FILE"
+        cat "$TEMPDIR/alsa-usbmixer.tmp" >> "$FILE"
+        echo "--endcollapse--" >> "$FILE"
+	echo "" >> "$FILE"
+	echo "" >> "$FILE"
 fi
 
 #If no command line options are specified, then run as though --with-all was specified
@@ -753,7 +753,7 @@ if [ -n "$1" ]; then
 			exit
 			;;
 		--upload)
-			UPLOAD=yes
+			UPLOAD='yes'
 			;;
 		--no-upload)
 			UPLOAD=no
@@ -761,11 +761,11 @@ if [ -n "$1" ]; then
 		--output)
 			shift
 			NFILE="$1"
-			KEEP_OUTPUT=yes
+			KEEP_OUTPUT='yes'
 			;;
 		--debug)
 			echo "Debugging enabled. $FILE and $TEMPDIR will not be deleted"
-			KEEP_FILES=yes
+			KEEP_FILES='yes'
 			echo ""
 			;;
 		--with-all)
@@ -896,11 +896,11 @@ fi
 if [ "$UPLOAD" = ask ]; then
 	if [ -n "$DIALOG" ]; then
 		dialog --backtitle "$BGTITLE" --title "Information collected" --yes-label " UPLOAD / SHARE " --no-label " SAVE LOCALLY " --defaultno --yesno "\n\nAutomatically upload ALSA information to $WWWSERVICE?" 10 80
-		DIALOG_EXIT_CODE="$?"
+		DIALOG_EXIT_CODE=$?
 		if [ "$DIALOG_EXIT_CODE" != 0 ]; then
 			UPLOAD=no
 		else
-			UPLOAD=yes
+			UPLOAD='yes'
 		fi
 	else
 		echo -n "Automatically upload ALSA information to $WWWSERVICE? [y/N] : "
@@ -908,7 +908,7 @@ if [ "$UPLOAD" = ask ]; then
 		if [ "$CONFIRM" != y ]; then
 			UPLOAD=no
 		else
-			UPLOAD=yes
+			UPLOAD='yes'
 		fi
 	fi
 
@@ -917,7 +917,7 @@ fi
 if [ "$UPLOAD" = no ]; then
 
 	mv -f "$FILE" "$NFILE" || exit 1
-	KEEP_OUTPUT=yes
+	KEEP_OUTPUT='yes'
 
 	if [[ -n "$DIALOG" ]]
 	then
@@ -945,9 +945,9 @@ else
 	wget -O - --tries=5 --timeout=60 --post-file="$FILE" 'https://pastebin.ca/quiet-paste.php?api='"${PASTEBINKEY}"'&encrypt=t&encryptpw=blahblah' &> "$TEMPDIR/wget.tmp"
 fi
 
-if [ "$?" -ne 0 ]; then
+if [ $? -ne 0 ]; then
 	mv -f "$FILE" "$NFILE" || exit 1
-	KEEP_OUTPUT=yes
+	KEEP_OUTPUT='yes'
 
 	if [ -n "$DIALOG" ]; then
 		dialog --backtitle "$BGTITLE" --title "Information not uploaded" --msgbox "An error occurred while contacting $WWWSERVICE.\n Your information was NOT automatically uploaded.\n\nYour ALSA information is in $NFILE" 10 100
@@ -966,7 +966,7 @@ fi
 if [ -n "$DIALOG" ]; then
 
 dialog --backtitle "$BGTITLE" --title "Information uploaded" --yesno "Would you like to see the uploaded information?" 5 100 
-DIALOG_EXIT_CODE="$?"
+DIALOG_EXIT_CODE=$?
 if [ "$DIALOG_EXIT_CODE" = 0 ]; then
 	grep -v alsa-info.txt "$FILE" > "$TEMPDIR/uploaded.txt"
 	dialog --backtitle "$BGTITLE" --textbox "$TEMPDIR/uploaded.txt" 0 0

--- a/alsa-info/alsa-info.sh
+++ b/alsa-info/alsa-info.sh
@@ -48,25 +48,25 @@ update() {
 	wget -O "$SHFILE" 'https://www.alsa-project.org/alsa-info.sh' >/dev/null 2>&1
 	REMOTE_VERSION="$(grep SCRIPT_VERSION "$SHFILE" | head -n1 | sed 's/.*=//')"
 	if [ -s "$SHFILE" ] && [ "$REMOTE_VERSION" != "$SCRIPT_VERSION" ]; then
-		if [[ -n "$DIALOG" ]]
+		if [[ -n $DIALOG ]]
 		then
 			OVERWRITE=
 			if [ -w "$0" ]; then
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to install it?\nNOTICE: The original file $0 will be overwritten!" 0 0
 				DIALOG_EXIT_CODE=$?
-				if [[ "$DIALOG_EXIT_CODE" = 0 ]]; then
+				if [[ $DIALOG_EXIT_CODE = 0 ]]; then
 				  OVERWRITE=yes
 				fi
 			fi
-			if [ -z "$OVERWRITE" ]; then
+			if [ -z $OVERWRITE ]; then
 				dialog --yesno "Newer version of ALSA-Info has been found\n\nDo you wish to download it?" 0 0
 				DIALOG_EXIT_CODE=$?
 			fi
-			if [[ "$DIALOG_EXIT_CODE" = 0 ]]
+			if [[ $DIALOG_EXIT_CODE = 0 ]]
 			then
 				echo "Newer version detected: $REMOTE_VERSION"
 				echo "To view the ChangeLog, please visit $CHANGELOG"
-				if [ "$OVERWRITE" = 'yes' ]; then
+				if [ $OVERWRITE = yes ]; then
 					cp "$SHFILE" "$0"
 					echo "ALSA-Info script has been updated to v $REMOTE_VERSION"
 					echo "Please re-run the script"
@@ -100,10 +100,10 @@ update() {
 }
 
 cleanup() {
-	if [ -n "$TEMPDIR" ] && [ "$KEEP_FILES" != 'yes' ]; then
+	if [ -n "$TEMPDIR" ] && [ $KEEP_FILES != yes ]; then
 		rm -rf "$TEMPDIR" 2>/dev/null
 	fi
-	test -n "$KEEP_OUTPUT" || rm -f "$NFILE"
+	test -n $KEEP_OUTPUT || rm -f "$NFILE"
 }
 
 
@@ -167,13 +167,13 @@ withdevices() {
 }
 
 withconfigs() {
-if [[ -e "$HOME/.asoundrc" ]] || [[ -e "/etc/asound.conf" ]] || [[ -e "$HOME/.asoundrc.asoundconf" ]]; then
+if [[ -e $HOME/.asoundrc ]] || [[ -e /etc/asound.conf ]] || [[ -e $HOME/.asoundrc.asoundconf ]]; then
         echo "!!ALSA configuration files" >> "$FILE"
         echo "!!------------------------" >> "$FILE"
         echo "" >> "$FILE"
 
         #Check for ~/.asoundrc
-        if [[ -e "$HOME/.asoundrc" ]]
+        if [[ -e $HOME/.asoundrc ]]
         then
                 echo "!!User specific config file (~/.asoundrc)" >> "$FILE"
                 echo "" >> "$FILE"
@@ -182,7 +182,7 @@ if [[ -e "$HOME/.asoundrc" ]] || [[ -e "/etc/asound.conf" ]] || [[ -e "$HOME/.as
                 echo "" >> "$FILE"
         fi
 	#Check for .asoundrc.asoundconf (seems to be Ubuntu specific)
-	if [[ -e "$HOME/.asoundrc.asoundconf" ]]
+	if [[ -e $HOME/.asoundrc.asoundconf ]]
 	then
 		echo "!!asoundconf-generated config file" >> "$FILE"
 		echo "" >> "$FILE"
@@ -209,7 +209,7 @@ withsysfs() {
 	case "$i" in
 	    */hwC?D?)
 		if [ -f "$i/init_pin_configs" ]; then
-		    if [ -z "$printed" ]; then
+		    if [ -z $printed ]; then
 			echo "!!Sysfs Files" >> "$FILE"
 			echo "!!-----------" >> "$FILE"
 			echo "" >> "$FILE"
@@ -224,7 +224,7 @@ withsysfs() {
 		;;
 	    esac
     done
-    if [ -n "$printed" ]; then
+    if [ -n $printed ]; then
 	echo "" >> "$FILE"
     fi
 }
@@ -273,7 +273,7 @@ withall() {
 get_alsa_library_version() {
 	ALSA_LIB_VERSION="$(grep VERSION_STR /usr/include/alsa/version.h 2>/dev/null | awk '{ print $3 }' | sed 's/"//g')"
 
-	if [ -z "$ALSA_LIB_VERSION" ]; then
+	if [ -z $ALSA_LIB_VERSION ]; then
 		if [ -f /etc/lsb-release ]; then
 			. /etc/lsb-release
 			case "$DISTRIB_ID" in
@@ -329,11 +329,11 @@ NFILE=""
 
 PASTEBIN=""
 WWWSERVICE='www.alsa-project.org'
-WELCOME='yes'
-PROCEED='yes'
+WELCOME=yes
+PROCEED=yes
 UPLOAD=ask
 REPEAT=""
-while [ -z "$REPEAT" ]; do
+while [ -z $REPEAT ]; do
 REPEAT=no
 case "$1" in
 	--update|--help|--about)
@@ -341,7 +341,7 @@ case "$1" in
 		PROCEED=no
 		;;
 	--upload)
-		UPLOAD='yes'
+		UPLOAD=yes
 		WELCOME=no
 		;;
 	--no-upload)
@@ -349,8 +349,8 @@ case "$1" in
 		WELCOME=no
 		;;
 	--pastebin)
-		PASTEBIN='yes'
-		WWWSERVICE='pastebin'
+		PASTEBIN=yes
+		WWWSERVICE=pastebin
 		;;
 	--no-dialog)
 		DIALOG=""
@@ -366,7 +366,7 @@ done
 
 
 #Script header output.
-if [ "$WELCOME" = 'yes' ]; then
+if [ $WELCOME = yes ]; then
 greeting_message="\
 
 This script visits the following commands/files to collect diagnostic
@@ -385,7 +385,7 @@ information about your ALSA installation and sound related hardware.
 See '$0 --help' for command line options.
 "
 if [ -n "$DIALOG" ]; then
-	dialog  --backtitle "$BGTITLE" \
+	dialog  --backtitle $BGTITLE \
 		--title "ALSA-Info script v $SCRIPT_VERSION" \
 		--msgbox "$greeting_message" 20 80
 else
@@ -404,7 +404,7 @@ fi
 
 trap cleanup 0
 
-if [ "$PROCEED" = 'yes' ]; then
+if [ $PROCEED = yes ]; then
 
 if [ -z "$LSPCI" ]; then
 	if [ -d /sys/bus/pci ]; then
@@ -417,7 +417,7 @@ TSTAMP="$(LANG=C TZ=UTC date)"
 DISTRO="$(grep -ihs "buntu\|SUSE\|Fedora\|PCLinuxOS\|MEPIS\|Mandriva\|Debian\|Damn\|Sabayon\|Slackware\|KNOPPIX\|Gentoo\|Zenwalk\|Mint\|Kubuntu\|FreeBSD\|Puppy\|Freespire\|Vector\|Dreamlinux\|CentOS\|Arch\|Xandros\|Elive\|SLAX\|Red\|BSD\|KANOTIX\|Nexenta\|Foresight\|GeeXboX\|Frugalware\|64\|SystemRescue\|Novell\|Solaris\|BackTrack\|KateOS\|Pardus\|ALT" /etc/{issue,*release,*version})"
 read -r KERNEL_RELEASE KERNEL_MACHINE KERNEL_PROCESSOR KERNEL_OS < <(uname -rpmo)
 read -r KERNEL_VERSION < <(uname -v)
-if [[ "$KERNEL_VERSION" = *SMP* ]]; then KERNEL_SMP=Yes; else KERNEL_SMP=No; fi
+if [[ $KERNEL_VERSION = *SMP* ]]; then KERNEL_SMP=Yes; else KERNEL_SMP=No; fi
 ALSA_DRIVER_VERSION="$(cat /proc/asound/version | head -n1 | awk '{ print $7 }' | sed 's/\.$//')"
 get_alsa_library_version
 ALSA_UTILS_VERSION="$(amixer -v | awk '{ print $3 }')"
@@ -455,7 +455,7 @@ fi
 if [ -d /sys/bus/acpi/devices ]; then
     for f in /sys/bus/acpi/devices/*/status; do
 	ACPI_STATUS="$(cat "$f" 2>/dev/null)"
-	if [[ "$ACPI_STATUS" -ne 0 ]]; then
+	if [[ $ACPI_STATUS -ne 0 ]]; then
 	    echo "$f" $'\t' "$ACPI_STATUS" >> "$TEMPDIR/acpidevicestatus.tmp"
 	fi
     done
@@ -463,7 +463,7 @@ fi
 
 awk '{ print $2 " (card " $1 ")" }' < /proc/asound/modules > "$TEMPDIR/alsamodules.tmp" 2> /dev/null
 cat /proc/asound/cards > "$TEMPDIR/alsacards.tmp"
-if [[ ! -z "$LSPCI" ]]; then
+if [[ ! -z $LSPCI ]]; then
 	for class in 0401 0402 0403; do
 		lspci -vvnn -d "::$class" | sed -n '/^[^\t]/,+1p'
 	done > "$TEMPDIR/lspci.tmp"
@@ -492,7 +492,7 @@ cat /proc/asound/card*/stream[0-9]* > "$TEMPDIR/alsa-usbstream.tmp" 2> /dev/null
 cat /proc/asound/card*/usbmixer > "$TEMPDIR/alsa-usbmixer.tmp" 2> /dev/null
 
 #Fetch the info, and put it in FILE in a nice readable format.
-if [[ -z "$PASTEBIN" ]]; then
+if [[ -z $PASTEBIN ]]; then
 echo "upload=true&script=true&cardinfo=" > "$FILE"
 else
 echo "name=$USER&type=33&description=/tmp/alsa-info.txt&expiry=&s=Submit+Post&content=" > "$FILE"
@@ -555,56 +555,56 @@ echo "" >> "$FILE"
 echo "!!Sound Servers on this system" >> "$FILE"
 echo "!!----------------------------" >> "$FILE"
 echo "" >> "$FILE"
-if [[ -n "$PWINST" ]];then
+if [[ -n $PWINST ]];then
 [[ "$(pgrep '^(.*/)?pipewire$')" ]] && PWRUNNING=Yes || PWRUNNING=No
 echo "PipeWire:" >> "$FILE"
 echo "      Installed - Yes ($PWINST)" >> "$FILE"
 echo "      Running - $PWRUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$PAINST" ]];then
+if [[ -n $PAINST ]];then
 [[ "$(pgrep '^(.*/)?pulseaudio$')" ]] && PARUNNING=Yes || PARUNNING=No
 echo "Pulseaudio:" >> "$FILE"
 echo "      Installed - Yes ($PAINST)" >> "$FILE"
 echo "      Running - $PARUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$ESDINST" ]];then
+if [[ -n $ESDINST ]];then
 [[ "$(pgrep '^(.*/)?esd$')" ]] && ESDRUNNING=Yes || ESDRUNNING=No
 echo "ESound Daemon:" >> "$FILE"
 echo "      Installed - Yes ($ESDINST)" >> "$FILE"
 echo "      Running - $ESDRUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$ARTSINST" ]];then
+if [[ -n $ARTSINST ]];then
 [[ "$(pgrep '^(.*/)?artsd$')" ]] && ARTSRUNNING=Yes || ARTSRUNNING=No
 echo "aRts:" >> "$FILE"
 echo "      Installed - Yes ($ARTSINST)" >> "$FILE"
 echo "      Running - $ARTSRUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$JACKINST" ]];then
+if [[ -n $JACKINST ]];then
 [[ "$(pgrep '^(.*/)?jackd$')" ]] && JACKRUNNING=Yes || JACKRUNNING=No
 echo "Jack:" >> "$FILE"
 echo "      Installed - Yes ($JACKINST)" >> "$FILE"
 echo "      Running - $JACKRUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$JACK2INST" ]];then
+if [[ -n $JACK2INST ]];then
 [[ "$(pgrep '^(.*/)?jackdbus$')" ]] && JACK2RUNNING=Yes || JACK2RUNNING=No
 echo "Jack2:" >> "$FILE"
 echo "      Installed - Yes ($JACK2INST)" >> "$FILE"
 echo "      Running - $JACK2RUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -n "$ROARINST" ]];then
+if [[ -n $ROARINST ]];then
 [[ "$(pgrep '^(.*/)?roard$')" ]] && ROARRUNNING=Yes || ROARRUNNING=No
 echo "RoarAudio:" >> "$FILE"
 echo "      Installed - Yes ($ROARINST)" >> "$FILE"
 echo "      Running - $ROARRUNNING" >> "$FILE"
 echo "" >> "$FILE"
 fi
-if [[ -z "$PAINST" && -z "$ESDINST" && -z "$ARTSINST" && -z "$JACKINST" && -z "$ROARINST" ]];then
+if [[ -z $PAINST && -z $ESDINST && -z $ARTSINST && -z $JACKINST && -z $ROARINST ]];then
 echo "No sound servers found." >> "$FILE"
 echo "" >> "$FILE"
 fi
@@ -616,7 +616,7 @@ cat "$TEMPDIR/alsacards.tmp" >> "$FILE"
 echo "" >> "$FILE"
 echo "" >> "$FILE"
 
-if [[ ! -z "$LSPCI" ]]; then
+if [[ ! -z $LSPCI ]]; then
 echo "!!PCI Soundcards installed in the system" >> "$FILE"
 echo "!!--------------------------------------" >> "$FILE"
 echo "" >> "$FILE"
@@ -753,7 +753,7 @@ if [ -n "$1" ]; then
 			exit
 			;;
 		--upload)
-			UPLOAD='yes'
+			UPLOAD=yes
 			;;
 		--no-upload)
 			UPLOAD=no
@@ -761,11 +761,11 @@ if [ -n "$1" ]; then
 		--output)
 			shift
 			NFILE="$1"
-			KEEP_OUTPUT='yes'
+			KEEP_OUTPUT=yes
 			;;
 		--debug)
 			echo "Debugging enabled. $FILE and $TEMPDIR will not be deleted"
-			KEEP_FILES='yes'
+			KEEP_FILES=yes
 			echo ""
 			;;
 		--with-all)
@@ -850,27 +850,27 @@ if [ -n "$1" ]; then
 	done
 fi
 
-if [ "$PROCEED" = no ]; then
+if [ $PROCEED = no ]; then
 	exit 1
 fi
 
-if [ -z "$WITHALL" ]; then
+if [ -z $WITHALL ]; then
 	withall
 fi
 
 # Check if wget is installed, and supports --post-file.
 if ! wget --help 2>/dev/null | grep -q post-file; then
 	# We couldn't find a suitable wget. If --upload was passed, tell the user to upload manually.
-	if [ "$UPLOAD" != yes ]; then
+	if [ $UPLOAD != yes ]; then
 		:
 	elif [ -n "$DIALOG" ]; then
-		if [ -z "$PASTEBIN" ]; then
-			dialog --backtitle "$BGTITLE" --msgbox "Could not automatically upload output to 'https://www.alsa-project.org'.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to 'https://www.alsa-project.org/cardinfo-db' and submit your post." 25 100
+		if [ -z $PASTEBIN ]; then
+			dialog --backtitle $BGTITLE --msgbox "Could not automatically upload output to 'https://www.alsa-project.org'.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to 'https://www.alsa-project.org/cardinfo-db' and submit your post." 25 100
 		else
-			dialog --backtitle "$BGTITLE" --msgbox "Could not automatically upload output to 'https://www.pastebin.ca'.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to 'https://www.pastebin.ca/upload.php' and submit your post." 25 100
+			dialog --backtitle $BGTITLE --msgbox "Could not automatically upload output to 'https://www.pastebin.ca'.\nPossible reasons are:\n\n    1. Couldn't find 'wget' in your PATH\n    2. Your version of wget is less than 1.8.2\n\nPlease manually upload $NFILE to 'https://www.pastebin.ca/upload.php' and submit your post." 25 100
 		fi
 	else
-		if [ -z "$PASTEBIN" ]; then
+		if [ -z $PASTEBIN ]; then
 			echo ""
 			echo "Could not automatically upload output to 'https://www.alsa-project.org'"
 			echo "Possible reasons are:"
@@ -893,35 +893,35 @@ if ! wget --help 2>/dev/null | grep -q post-file; then
 	UPLOAD=no
 fi
 
-if [ "$UPLOAD" = ask ]; then
+if [ $UPLOAD = ask ]; then
 	if [ -n "$DIALOG" ]; then
-		dialog --backtitle "$BGTITLE" --title "Information collected" --yes-label " UPLOAD / SHARE " --no-label " SAVE LOCALLY " --defaultno --yesno "\n\nAutomatically upload ALSA information to $WWWSERVICE?" 10 80
+		dialog --backtitle $BGTITLE --title "Information collected" --yes-label " UPLOAD / SHARE " --no-label " SAVE LOCALLY " --defaultno --yesno "\n\nAutomatically upload ALSA information to $WWWSERVICE?" 10 80
 		DIALOG_EXIT_CODE=$?
-		if [ "$DIALOG_EXIT_CODE" != 0 ]; then
+		if [ $DIALOG_EXIT_CODE != 0 ]; then
 			UPLOAD=no
 		else
-			UPLOAD='yes'
+			UPLOAD=yes
 		fi
 	else
 		echo -n "Automatically upload ALSA information to $WWWSERVICE? [y/N] : "
 		read -e CONFIRM
-		if [ "$CONFIRM" != y ]; then
+		if [ $CONFIRM != y ]; then
 			UPLOAD=no
 		else
-			UPLOAD='yes'
+			UPLOAD=yes
 		fi
 	fi
 
 fi
 
-if [ "$UPLOAD" = no ]; then
+if [ $UPLOAD = no ]; then
 
 	mv -f "$FILE" "$NFILE" || exit 1
-	KEEP_OUTPUT='yes'
+	KEEP_OUTPUT=yes
 
-	if [[ -n "$DIALOG" ]]
+	if [[ -n $DIALOG ]]
 	then
-		dialog --backtitle "$BGTITLE" --title "Information collected" --msgbox "\n\nYour ALSA information is in $NFILE" 10 60
+		dialog --backtitle $BGTITLE --title "Information collected" --msgbox "\n\nYour ALSA information is in $NFILE" 10 60
 	else
 		echo ""
 		echo "Your ALSA information is in $NFILE"
@@ -932,14 +932,14 @@ if [ "$UPLOAD" = no ]; then
 
 fi # UPLOAD
 
-if [[ -n "$DIALOG" ]]
+if [[ -n $DIALOG ]]
 then
-	dialog --backtitle "$BGTITLE" --infobox "Uploading information to $WWWSERVICE ..." 6 70
+	dialog --backtitle $BGTITLE --infobox "Uploading information to $WWWSERVICE ..." 6 70
 else
 	echo -n "Uploading information to $WWWSERVICE ..."
 fi
 
-if [[ -z "$PASTEBIN" ]]; then
+if [[ -z $PASTEBIN ]]; then
 	wget -O - --tries=5 --timeout=60 --post-file="$FILE" 'https://www.alsa-project.org/cardinfo-db/' &> "$TEMPDIR/wget.tmp"
 else
 	wget -O - --tries=5 --timeout=60 --post-file="$FILE" 'https://pastebin.ca/quiet-paste.php?api='"${PASTEBINKEY}"'&encrypt=t&encryptpw=blahblah' &> "$TEMPDIR/wget.tmp"
@@ -947,10 +947,10 @@ fi
 
 if [ $? -ne 0 ]; then
 	mv -f "$FILE" "$NFILE" || exit 1
-	KEEP_OUTPUT='yes'
+	KEEP_OUTPUT=yes
 
 	if [ -n "$DIALOG" ]; then
-		dialog --backtitle "$BGTITLE" --title "Information not uploaded" --msgbox "An error occurred while contacting $WWWSERVICE.\n Your information was NOT automatically uploaded.\n\nYour ALSA information is in $NFILE" 10 100
+		dialog --backtitle $BGTITLE --title "Information not uploaded" --msgbox "An error occurred while contacting $WWWSERVICE.\n Your information was NOT automatically uploaded.\n\nYour ALSA information is in $NFILE" 10 100
 	else
 		echo ""
 		echo "An error occurred while contacting $WWWSERVICE."
@@ -967,9 +967,9 @@ if [ -n "$DIALOG" ]; then
 
 dialog --backtitle "$BGTITLE" --title "Information uploaded" --yesno "Would you like to see the uploaded information?" 5 100 
 DIALOG_EXIT_CODE=$?
-if [ "$DIALOG_EXIT_CODE" = 0 ]; then
+if [ $DIALOG_EXIT_CODE = 0 ]; then
 	grep -v alsa-info.txt "$FILE" > "$TEMPDIR/uploaded.txt"
-	dialog --backtitle "$BGTITLE" --textbox "$TEMPDIR/uploaded.txt" 0 0
+	dialog --backtitle $BGTITLE --textbox "$TEMPDIR/uploaded.txt" 0 0
 fi
 
 clear
@@ -982,7 +982,7 @@ echo ""
 
 fi # dialog
 
-if [ -z "$PASTEBIN" ]; then
+if [ -z $PASTEBIN ]; then
 	FINAL_URL="$(grep 'SUCCESS:' "$TEMPDIR/wget.tmp" | cut -d ' ' -f 2)"
 else
 	FINAL_URL="$(grep 'SUCCESS:' "$TEMPDIR/wget.tmp" | sed -n 's/.*\:\([0-9]\+\).*/https:\/\/pastebin.ca\/\1/p')"


### PR DESCRIPTION
This commit:
- Added double quotes to common expansions; removed quotes from strings; 
- Changed REQUIRES to an indexed array and changed the corresponding for loop; 
- Added curly braces where feasibly necessary; 
- Removed a few unnecessary trailing semi-colons; 
- Put URL's in single quotes to prevent any possible expansions, except for within the sed command on line 988. 
- Some logic structures may depend on word splitting, on lines 641, 643, 654, and 667, so I left those as-is for this commit. 
- Double exclamation marks in double quotes allow history expansion which is usually disabled in non-interactive shells, so I left those as-is also.
- Single quoted instances of 'yes' as a parameter value, since it's also a command name, which in certain contexts could be executed.
- Removed quotes from instances of '$?' since it can only expand to an integer and cannot be unset.

Some additional issues for consideration of further efforts (credit: shellcheck):
- variables 'inp' on line 87 and 'KERNEL_RELEASE' on line 418 appear unused;
- https://pastebin.ca is offline