### PR TITLE
configure: Add large file support via CFLAGS

### DIFF
--- a/alsactl/Makefile.am
+++ b/alsactl/Makefile.am
@@ -7,7 +7,7 @@ man_MANS += alsactl_init.7
 endif
 EXTRA_DIST=alsactl.1 alsactl_init.xml
 
-AM_CFLAGS = -D_GNU_SOURCE
+AM_CFLAGS = -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
 
 alsactl_SOURCES=alsactl.c state.c lock.c utils.c init_parse.c init_ucm.c \
 		daemon.c monitor.c clean.c info.c

--- a/alsaucm/Makefile.am
+++ b/alsaucm/Makefile.am
@@ -10,7 +10,8 @@ alsaucm_SOURCES = usecase.c dump.c
 noinst_HEADERS = usecase.h
 
 AM_CPPFLAGS = \
-         -Wall -I$(top_srcdir)/include
+         -Wall -I$(top_srcdir)/include \
+         -D_FILE_OFFSET_BITS=64
 
 %.1: %.rst
 	rst2man $< > $@

--- a/amidi/Makefile.am
+++ b/amidi/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include \
+              -D_FILE_OFFSET_BITS=64
 EXTRA_DIST = amidi.1
 
 bin_PROGRAMS = amidi

--- a/axfer/Makefile.am
+++ b/axfer/Makefile.am
@@ -8,7 +8,8 @@ man_MANS = \
 
 # To include headers for gettext and version.
 AM_CPPFLAGS = \
-	-I$(top_srcdir)/include
+	-I$(top_srcdir)/include \
+	-D_FILE_OFFSET_BITS=64
 
 # Unit tests.
 SUBDIRS = \

--- a/seq/aplaymidi/Makefile.am
+++ b/seq/aplaymidi/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include \
+              -D_FILE_OFFSET_BITS=64
 EXTRA_DIST = aplaymidi.1 arecordmidi.1
 
 bin_PROGRAMS = aplaymidi arecordmidi

--- a/speaker-test/Makefile.am
+++ b/speaker-test/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include \
+              -D_FILE_OFFSET_BITS=64
 SUBDIRS= samples
 LDADD = $(LIBINTL) -lm
 

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -16,7 +16,8 @@ alsatplg_SOURCES = topology.c pre-processor.c pre-process-class.c pre-process-ob
 noinst_HEADERS = topology.h pre-processor.h pre-process-external.h
 
 AM_CPPFLAGS = \
-         -Wall -I$(top_srcdir)/include -DALSA_TOPOLOGY_PLUGIN_DIR=\"@ALSA_TOPOLOGY_PLUGIN_DIR@\"
+         -Wall -I$(top_srcdir)/include -DALSA_TOPOLOGY_PLUGIN_DIR=\"@ALSA_TOPOLOGY_PLUGIN_DIR@\" \
+         -D_FILE_OFFSET_BITS=64
 
 alsatplg_LDADD = $(ALSA_TOPOLOGY_LIBS)
 

--- a/topology/nhlt/Makefile.am
+++ b/topology/nhlt/Makefile.am
@@ -2,7 +2,8 @@ alsatplg_module_nhlt_LTLIBRARIES = libalsatplg_module_nhlt.la
 
 alsatplg_module_nhltdir = @ALSA_TOPOLOGY_PLUGIN_DIR@
 
-AM_CFLAGS = -Wall -fvisibility=hidden -I$(top_srcdir)/include -I$(top_srcdir)/topology
+AM_CFLAGS = -Wall -fvisibility=hidden -I$(top_srcdir)/include -I$(top_srcdir)/topology \
+            -D_FILE_OFFSET_BITS=64
 AM_LDFLAGS = -module -avoid-version -export-dynamic -no-undefined $(LDFLAGS_NOUNDEFINED)
 
 libalsatplg_module_nhlt_la_SOURCES = nhlt-processor.c \


### PR DESCRIPTION
Currently scanelf (pax-utils) detects missing LFS support in the following files/calls:
__open_2,fstat,mmap,open,scandir,stat,alphasort,lstat /usr/sbin/alsactl fopen /usr/lib/alsa-topology/libalsatplg_module_nhlt.so fopen /usr/bin/alsaucm
fopen /usr/bin/aplaymidi
__open_2,open /usr/bin/alsatplg
fstat,open,__open_2 /usr/bin/axfer
fopen /usr/bin/arecordmidi
fopen,__open_2 /usr/bin/speaker-test
creat,__open_2,lseek /usr/bin/amidi

Note that this may cause problems on systems with a 32-bit kernel, but I've tested playing audio on a more recent 32-bit system with a 64-bit kernel.

Let me know if you'd prefer a different approach! Notably the existing AC_SYS_LARGEFILE in configure.ac was not having any effect in my environment. I'm building on a 64-bit host for a 32-bit target.