### PR TITLE
alsactl: add define to compile with glibc 2.38

### DIFF
--- a/alsactl/init_sysdeps.c
+++ b/alsactl/init_sysdeps.c
@@ -18,6 +18,7 @@
  */
 
 #if defined(__GLIBC__) && !(defined(__UCLIBC__) && defined(__USE_BSD))
+#if !(__GLIBC_PREREQ(2, 38))
 static size_t strlcpy(char *dst, const char *src, size_t size)
 {
 	size_t bytes = 0;
@@ -60,4 +61,5 @@ static size_t strlcat(char *dst, const char *src, size_t size)
 	*q = '\0';
 	return bytes;
 }
+#endif /* !(__GLIBC_PREREQ(2, 38)) */
 #endif /* __GLIBC__ */


### PR DESCRIPTION
strlcat and strlcpy have been added to glibc 2.38. update the defines to use the glibc versions, and not conflict with string.h.

ref:
- https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199