### PR TITLE
bat: really skip analysis of the first period and update related comment

### DIFF
--- a/bat/analyze.c
+++ b/bat/analyze.c
@@ -299,7 +299,7 @@ static int calculate_noise(struct bat *bat, float *src, int channel)
 	/* each section has 2 sine periods, the first one for locating
 	 * and the second one for noise calculating */
 	int nsamples_per_section = nsamples * 2;
-	/* all sine periods will be calculated except the first one */
+	/* all sine periods will be calculated except the first and last one */
 	int nsection = bat->frames / nsamples - 1;
 
 	fprintf(bat->log, _("samples per period: %d\n"), nsamples);
@@ -331,7 +331,7 @@ static int calculate_noise(struct bat *bat, float *src, int channel)
 	/* calculate average noise level */
 	sum_snr_pc = 0.0;
 	cnt_clean = cnt_noise = 0;
-	for (i = 0, offset = 0; i < nsection; i++) {
+	for (i = 1, offset = nsamples; i < nsection; i++) {
 		na.snr_db = SNR_DB_INVALID;
 
 		err = calculate_noise_one_period(bat, &na, src + offset,


### PR DESCRIPTION
Prior to this change bat/analyze.c would skip the last period of the recording, contrary to the comment in the code which stated the first period was meant to be skipped.

The comment has been updated to state that both the first and last period are skipped and the code has been updated to match.