### PR TITLE
aplay: improve xrun logs

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -1656,12 +1656,6 @@ static void xrun(void)
 		prg_exit(EXIT_FAILURE);
 	}
 	if (snd_pcm_status_get_state(status) == SND_PCM_STATE_XRUN) {
-		if (fatal_errors) {
-			error(_("fatal %s: %s"),
-					stream == SND_PCM_STREAM_PLAYBACK ? _("underrun") : _("overrun"),
-					snd_strerror(res));
-			prg_exit(EXIT_FAILURE);
-		}
 		if (monotonic) {
 #ifdef HAVE_CLOCK_GETTIME
 			struct timespec now, diff, tstamp;
@@ -1686,6 +1680,12 @@ static void xrun(void)
 		if (verbose) {
 			fprintf(stderr, _("Status:\n"));
 			snd_pcm_status_dump(status, log);
+		}
+		if (fatal_errors) {
+			error(_("fatal %s: %s"),
+					stream == SND_PCM_STREAM_PLAYBACK ? _("underrun") : _("overrun"),
+					snd_strerror(res));
+			prg_exit(EXIT_FAILURE);
 		}
 		if ((res = snd_pcm_prepare(handle))<0) {
 			error(_("xrun: prepare error: %s"), snd_strerror(res));

--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -1473,6 +1473,15 @@ static void set_params(void)
 	err = snd_pcm_sw_params_set_stop_threshold(handle, swparams, stop_threshold);
 	assert(err >= 0);
 
+	err = snd_pcm_sw_params_set_tstamp_mode(handle, swparams, SND_PCM_TSTAMP_ENABLE);
+	assert(err >= 0);
+
+	if (monotonic)
+		err = snd_pcm_sw_params_set_tstamp_type(handle, swparams, SND_PCM_TSTAMP_TYPE_MONOTONIC);
+	else
+		err = snd_pcm_sw_params_set_tstamp_type(handle, swparams, SND_PCM_TSTAMP_TYPE_GETTIMEOFDAY);
+	assert(err >= 0);
+
 	if (snd_pcm_sw_params(handle, swparams) < 0) {
 		error(_("unable to install sw params:"));
 		snd_pcm_sw_params_dump(swparams, log);


### PR DESCRIPTION
Add a pcm_status on xrun and a non-zero timestamp.