### PR TITLE
topology: Fix dmic nhlt blob building, and fix $[] attribute value resolving

### DIFF
--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -1641,7 +1641,7 @@ pre_process_object_variables_expand_fcn(snd_config_t **dst, const char *str, voi
  * or '\0'.
  *
  * In '$[<contents>]' case all letters but '[' and ']' are allow in
- * any sequence. Nested '[]' is also allowed if the number if '[' and
+ * any sequence. Nested '[]' is also allowed if the number of '[' and
  * ']' match.
  *
  * The function modifies *stringp, and *prefix - if not NULL - points

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -1589,6 +1589,7 @@ pre_process_object_variables_expand_fcn(snd_config_t **dst, const char *str, voi
 	snd_config_t *object_cfg = tplg_pp->current_obj_cfg;
 	snd_config_t *conf_defines;
 	const char *object_id;
+	const char *val;
 	int ret;
 
 	ret = snd_config_search(tplg_pp->input_cfg, "Define", &conf_defines);
@@ -1600,14 +1601,31 @@ pre_process_object_variables_expand_fcn(snd_config_t **dst, const char *str, voi
 	if (ret >= 0)
 		return ret;
 
+	/* No global define found, proceeed to object attribute search */
 	if (snd_config_get_id(object_cfg, &object_id) < 0)
 		return -EINVAL;
 
 	/* find variable from object attribute values if not found in global definitions */
 	ret = pre_process_find_variable(dst, str, object_cfg);
-	if (ret < 0)
+	if (ret < 0) {
 		SNDERR("Failed to find definition for attribute %s in '%s' object\n",
 		       str, object_id);
+		return ret;
+	}
+
+	/* the extracted value may contain a nested $-expression */
+	if (snd_config_get_string(*dst, &val) >= 0) {
+		if (val[0] == '$') {
+			char *var = strdup(val);
+
+			snd_config_remove(*dst);
+			snd_config_delete(*dst);
+			ret = snd_config_evaluate_string(dst, var,
+							 pre_process_object_variables_expand_fcn,
+							 tplg_pp);
+			free(var);
+		}
+	}
 
 	return ret;
 }


### PR DESCRIPTION
This PR fixes two issues. FIrst it fixes https://github.com/thesofproject/sof/issues/8670 and then it adds to $[] expressions define handling in object attribute, so that we can use DMIC frequency defines in format objects, wihout ibs and obs attributes referring to those attributes breaking it. 