### PR TITLE
aplaymidi: Set event completely for tempo event

### DIFF
--- a/seq/aplaymidi/aplaymidi.c
+++ b/seq/aplaymidi/aplaymidi.c
@@ -819,6 +819,8 @@ static void play_midi(void)
 		ev.time.tick = event->tick;
 		ev.dest = ports[event->port];
 		if (event->type == SND_SEQ_EVENT_TEMPO) {
+			snd_seq_ev_set_fixed(&ev);
+			ev.type = event->type;
 			ev.dest.client = SND_SEQ_CLIENT_SYSTEM;
 			ev.dest.port = SND_SEQ_PORT_SYSTEM_TIMER;
 			ev.data.queue.queue = queue;


### PR DESCRIPTION
After UMP support was added in b399fb8 ev.type setting was inadvertently dropped in the code path handling tempo meta event. This is causing tempo meta events to not be handled at all. Moreover, snd_seq_ev_set_fixed is also missing so MIDI files with variable events such as SYSEX before the tempo meta event usually are causing a segfault.

Fixes https://github.com/alsa-project/alsa-utils/issues/241