### PR TITLE
chore: Use actions/checkout@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         dnf -y install @development-tools libtool bzip2 gettext-devel ncurses-devel
 
     - name: Checkout alsa-lib
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: alsa-project/alsa-lib
         ref: master
@@ -41,7 +41,7 @@ jobs:
         make install
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: alsa-utils
     - name: Checkout all tags
@@ -128,7 +128,7 @@ jobs:
         apt-get install -y git build-essential pkg-config m4 autoconf automake libtool gettext ncurses-dev
 
     - name: Checkout alsa-lib
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: alsa-project/alsa-lib
         ref: master
@@ -149,7 +149,7 @@ jobs:
         make install
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         mv configure.ac configure.ac.old


### PR DESCRIPTION
Refer to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.
