### PR TITLE
aplay: fix S24_LE wav header

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -2719,11 +2719,11 @@ static void begin_wave(int fd, size_t cnt)
 	case SND_PCM_FORMAT_S16_LE:
 		bits = 16;
 		break;
+	case SND_PCM_FORMAT_S24_LE: /* S24_LE is 24 bits stored in 32 bit width with 8 bit padding */
 	case SND_PCM_FORMAT_S32_LE:
-        case SND_PCM_FORMAT_FLOAT_LE:
+	case SND_PCM_FORMAT_FLOAT_LE:
 		bits = 32;
 		break;
-	case SND_PCM_FORMAT_S24_LE:
 	case SND_PCM_FORMAT_S24_3LE:
 		bits = 24;
 		break;


### PR DESCRIPTION
S24_LE is 32 bits in width storing 24 bits of data and 8 bits of padding So wav header needs to be 32 bits not 24