### PR TITLE
FIXES: alsamixer lowering volume control widget past 0 causes hostile volume spike to 100

### DIFF
--- a/alsamixer/mixer_widget.c
+++ b/alsamixer/mixer_widget.c
@@ -332,7 +332,7 @@ static void change_volume_relative(struct control *control, int delta, unsigned 
 	double (*get_func)(snd_mixer_elem_t *, snd_mixer_selem_channel_id_t);
 	int (*set_func)(snd_mixer_elem_t *, snd_mixer_selem_channel_id_t, double, int);
 	double left = 0, right = 0;
-	int dir;
+	int dir = delta > 0 ? 1 : -1;
 
 	if (!(control->flags & HAS_VOLUME_1))
 		channels = LEFT;
@@ -343,16 +343,15 @@ static void change_volume_relative(struct control *control, int delta, unsigned 
 		get_func = get_normalized_capture_volume;
 		set_func = set_normalized_capture_volume;
 	}
-	if (channels & LEFT)
-		left = get_func(control->elem, control->volume_channels[0]);
-	if (channels & RIGHT)
-		right = get_func(control->elem, control->volume_channels[1]);
-	dir = delta > 0 ? 1 : -1;
 	if (channels & LEFT) {
+		left = get_func(control->elem, control->volume_channels[0]);
+		if (left == 0 && dir == -1) return;
 		left = clamp_volume(left + delta / 100.0);
 		set_func(control->elem, control->volume_channels[0], left, dir);
 	}
 	if (channels & RIGHT) {
+		right = get_func(control->elem, control->volume_channels[1]);
+		if (right == 0 && dir == -1) return;
 		right = clamp_volume(right + delta / 100.0);
 		set_func(control->elem, control->volume_channels[1], right, dir);
 	}


### PR DESCRIPTION
bug: lowering volume below 0 causes volume to overflow and spike to 100% volume hurting my ears.

to reproduce:  when holding down z,x,c to lower the volume, the volume spikes to 100% and then down to 0% over and over

background:
when volume is already 0 and direction is -1 (lowering volume) - but lower than 0 is impossible
the function `set_normalized_volume` @ volume-mapping.c is eventually still called anyway
`value = lrint_dir(6000.0 * log10(volume), dir) + max;`
and volume is 0, so
log10(0) resolves to negative infinity, so
value overflows past infinity. 9223372036854775802
![alsamixer-alsa-utils-volumemap-bug3_2024-04-18_13-27-23](https://github.com/alsa-project/alsa-utils/assets/3683744/d382c59b-0e71-420f-8495-4d5d863f3734)


my fix:
this function `change_volume_relative` function will now skip execution of the set_normalized_playback_volume function when volume is 0 and the dir is -1 
TLDR: (stop trying to set a lower volume than 0)