### PR TITLE
alsactl: don't free a card pointing NULL

### DIFF
--- a/alsactl/daemon.c
+++ b/alsactl/daemon.c
@@ -451,8 +451,11 @@ out:
 	free(pfd);
 	remove(pidfile);
 	if (cards) {
-		for (i = 0; i < count; i++)
+		for (i = 0; i < count; i++) {
+			if (cards[i] == NULL)
+				continue;
 			card_free(&cards[i]);
+		}
 		free(cards);
 	}
 	return 0;


### PR DESCRIPTION
alsactl distributed as part of Fedora 40 got a SEGV:

    # journalctl
    ...
    May 17 00:55:58 dev64.localdomain kernel: alsactl[1923]: segfault at 28 ip 00005600705b3373 sp 00007ffd9712bef0 error 4 in alsactl[5600705af000+13000] likely on CPU 5 (core 8, socket 0)
    ...

As the following output of the debug session, card_free() tried a card pointing NULL:

    $ sudo coredumpctl debug alsactl
	       PID: 1923 (alsactl)
	       UID: 0 (root)
	       GID: 0 (root)
	    Signal: 11 (SEGV)
	 Timestamp: Fri 2024-05-17 00:55:58 JST (3h 34min ago)
      Command Line: /usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/lib/alsa/init/00main rdaemon
	Executable: /usr/sbin/alsactl
     Control Group: /system.slice/alsa-state.service
	      Unit: alsa-state.service
	     Slice: system.slice
	   Boot ID: 241b5a2ef86f4940bb3d340583c80d88
	Machine ID: 437365709a8c488c9481ee4b6651c2ec
	  Hostname: dev64.localdomain
	   Storage: /var/lib/systemd/coredump/core.alsactl.0.241b5a2ef86f4940bb3d340583c80d88.1923.1715874958000000.zst (present)
      Size on Disk: 81.7K
	   Package: alsa-utils/1.2.11-1.fc40
	  build-id: 3b6fec58b3566d666d6e9fd48e8fcf04f03f0152
	   Message: Process 1923 (alsactl) of user 0 dumped core.

		    Module libasound.so.2 from rpm alsa-lib-1.2.11-2.fc40.x86_64
		    Module alsactl from rpm alsa-utils-1.2.11-1.fc40.x86_64
		    Stack trace of thread 1923:
		    #0  0x00005600705b3373 card_free (alsactl + 0xa373)
		    #1  0x00005600705c0e54 state_daemon (alsactl + 0x17e54)
		    #2  0x00005600705b2339 main (alsactl + 0x9339)
		    #3  0x00007f4c0b9b7088 __libc_start_call_main (libc.so.6 + 0x2a088)
		    #4  0x00007f4c0b9b714b __libc_start_main_impl (libc.so.6 + 0x2a14b)
		    #5  0x00005600705b2df5 _start (alsactl + 0x9df5)
		    ELF object binary architecture: AMD x86-64

    GNU gdb (Fedora Linux) 14.2-1.fc40
    Copyright (C) 2023 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
    This is free software: you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.
    Type "show copying" and "show warranty" for details.
    This GDB was configured as "x86_64-redhat-linux-gnu".
    Type "show configuration" for configuration details.
    For bug reporting instructions, please see:
    <https://www.gnu.org/software/gdb/bugs/>.
    Find the GDB manual and other documentation resources online at:
	<http://www.gnu.org/software/gdb/documentation/>.

    For help, type "help".
    Type "apropos word" to search for commands related to "word"...
    Reading symbols from /usr/sbin/alsactl...
    Reading symbols from /usr/lib/debug/usr/sbin/alsactl-1.2.11-1.fc40.x86_64.debug...
    [New LWP 1923]
    [Thread debugging using libthread_db enabled]
    Using host libthread_db library "/lib64/libthread_db.so.1".
    Core was generated by `/usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --init'.
    Program terminated with signal SIGSEGV, Segmentation fault.
    #0  free_list (list=0x20) at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/daemon.c:73
    73		for (i = 0; i < list->size; i++)
    (gdb) where
    #0  free_list (list=0x20) at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/daemon.c:73
    #1  card_free (card=card@entry=0x5600707455f0) at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/daemon.c:82
    #2  0x00005600705c0e54 in state_daemon (file=file@entry=0x5600705c31a1 "/var/lib/alsa/asound.state", cardname=cardname@entry=0x0, period=period@entry=300,
	pidfile=pidfile@entry=0x5600705c3170 "/var/run/alsactl.pid") at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/daemon.c:455
    #3  0x00005600705b2339 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/alsactl.c:459
    (gdb) list
    68
    69	static void free_list(struct id_list *list)
    70	{
    71		int i;
    72
    73		for (i = 0; i < list->size; i++)
    74			free(list->list[i]);
    75		free(list->list);
    76	}
    77
    (gdb) up
    #1  card_free (card=card@entry=0x5600707455f0) at /usr/src/debug/alsa-utils-1.2.11-1.fc40.x86_64/alsactl/daemon.c:82
    82		free_list(&c->blacklist);
    (gdb) p c
    $1 = (struct card *) 0x0
    (gdb)