### PR TITLE
aplay: Print '=== PAUSE ===' only if it is supported

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -1618,6 +1618,8 @@ static void do_pause(void)
 		error(_("pause push error: %s"), snd_strerror(err));
 		return;
 	}
+	fprintf(stderr, _("\r=== PAUSE ===                                                            "));
+	fflush(stderr);
 	while (1) {
 		b = wait_for_input();
 		if (b == ' ' || b == '\r') {
@@ -1642,8 +1644,6 @@ static void check_stdin(void)
 		while (read(fileno(stdin), &b, 1) == 1) {
 			if (b == ' ' || b == '\r') {
 				while (read(fileno(stdin), &b, 1) == 1);
-				fprintf(stderr, _("\r=== PAUSE ===                                                            "));
-				fflush(stderr);
 				do_pause();
 				fprintf(stderr, "                                                                          \r");
 				fflush(stderr);


### PR DESCRIPTION
Instead of printing the '=== PAUSE ===' unconditionally before calling do_pause(), move it to the function and only print it if the stream can be paused.

If the stream cannot be paused that the '=== PAUSE ===' will be replaced by `PAUSE command ignored (no hw support)` immediately, which is not observable by users but automation scripts will catch the '=== PAUSE ===' and might think that the stream is indeed got paused.

Move the print into do_pause() function after the snd_pcm_pause() have returned without error to make sure it is only printed if the stream is paused and we are waiting for the pause release from user to proceed.