### PR TITLE
gitcompile: restore ACLOCAL_FLAGS ability to use ../alsa-lib/utils/

### DIFF
--- a/gitcompile
+++ b/gitcompile
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if test -d ../alsa-lib/utils && ! test -r `aclocal --print-ac-dir`/alsa.m4; then
-  alsa_m4_flags="-I ../alsa-lib/utils"
+  ACLOCAL_FLAGS="$ACLOCAL_FLAGS -I ../alsa-lib/utils"
 fi
-aclocal $alsa_m4_flags $ACLOCAL_FLAGS
+aclocal $ACLOCAL_FLAGS
 # save original files to avoid stupid modifications by gettextize
 cp Makefile.am Makefile.am.ok
 cp configure.ac configure.ac.ok


### PR DESCRIPTION
Fixes cryptic "error macro 'AM_PATH_ALSA' not found in library configure.ac:22" when attempting a local install as described at https://thesofproject.github.io/latest/getting_started/build-guide/build-from-scratch.html#build-alsa-lib-and-alsa-utils-from-source

Fixes giant commit f9e6010d5ec7 ("topology: plugins - add Intel nhlt encoder plugin") which added a second invocation of `aclocal` in 2021 but forgot the extra `$alsa_m4_flags`.

To avoid duplication, do not fix by adding the missing `$alsa_m4_flags` to the second aclocal invocation. Instead, drop that variable and append `-I ../alsa-lib/utils` directly to $ACLOCAL_FLAGS

Signed-off-by: Marc Herbert <marc.herbert@intel.com>