### PR TITLE
topology: Fix strcat() to uninitialized memory in add_define()

### DIFF
--- a/topology/topology.c
+++ b/topology/topology.c
@@ -398,9 +398,12 @@ static int add_define(char **defs, char *d)
 	size_t len = (*defs ? strlen(*defs) : 0) + strlen(d) + 2;
 	char *m = realloc(*defs, len);
 	if (m) {
-		if (*defs)
+		if (*defs) {
 			strcat(m, ",");
-		strcat(m, d);
+			strcat(m, d);
+		} else {
+			strcpy(m, d);
+		}
 		*defs = m;
 		return 0;
 	}


### PR DESCRIPTION
If *defs == NULL the realloc() will be a simple malloc() and return a pointer to uninitialized memory. Doing a strcat() to this is bad, so in that case strcpy() the string into the newly allocated buffer.

This fixes the buffer overflow bug, such as:

*** buffer overflow detected ***: terminated
Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory
(gdb) bt
    at ../sysdeps/posix/libc_fatal.c:132
    at ./debug/fortify_fail.c:24
    dest=dest@entry=0x5555555682c0 "hUUU\005PLATFORM=mtl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-sdw-cs42l42-l0-max98363-l2-4ch-48k-96k.bin,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,DMIC1_ENABLE=passth"...,
    src=src@entry=0x7fffffffe0fa "PLATFORM=mtl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-sdw-cs42l42-l0-max98363-l2-4ch-48k-96k.bin,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,DMIC1_ENABLE=passthrough"..., destlen=<optimized out>) at ./debug/strcat_chk.c:34
    __src=0x7fffffffe0fa "PLATFORM=mtl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-sdw-cs42l42-l0-max98363-l2-4ch-48k-96k.bin,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,DMIC1_ENABLE=passthrough"...,
    __dest=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:130
    d=0x7fffffffe0fa "PLATFORM=mtl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-sdw-cs42l42-l0-max98363-l2-4ch-48k-96k.bin,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,DMIC1_ENABLE=passthrough"...,
    defs=<synthetic pointer>) at topology.c:400