### PR TITLE
alsactl: 90-alsa-restore.rules - fix AMD acp-pdm-mach link name acp-dmic-codec

### DIFF
--- a/alsactl/90-alsa-restore.rules.in
+++ b/alsactl/90-alsa-restore.rules.in
@@ -14,7 +14,7 @@ DRIVERS=="snd_hda_intel", TEST=="device/pcmC$env{ALSA_CARD_NUMBER}D0p", RUN+="/b
 TEST=="device/device/acp3x-dmic-capture", GOTO="alsa_hda_analog"
 TEST=="device/device/acp6x-dmic-capture", GOTO="alsa_hda_analog"
 TEST=="device/device/acp63-dmic-capture", GOTO="alsa_hda_analog"
-TEST=="device/device/acp-pdm-dmic", GOTO="alsa_hda_analog"
+TEST=="device/device/acp-dmic-codec", GOTO="alsa_hda_analog"
 GOTO="alsa_restore_std"
 
 LABEL="alsa_hda_analog"


### PR DESCRIPTION
The link name of AMD ACP digital microphones driver acp-pdm-mach is acp-dmic-codec.
fix it to make UCM initialize it again.

Fixes: 8116639 ("alsactl: 90-alsa-restore.rules - add support for AMD ACP digital microphone")

# arecord -l
**** List of CAPTURE Hardware Devices ****
card 1: Generic_1 [HD-Audio Generic], device 0: ALC257 Analog [ALC257 Analog]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 2: acppdmmach [acp-pdm-mach], device 0: (null) dmic-hifi-0 []
  Subdevices: 1/1
  Subdevice #0: subdevice #0

# ls -la /sys/class/sound/controlC2/device/
total 0
drwxr-xr-x 5 root root    0 Nov 20 15:50 .
drwxr-xr-x 3 root root    0 Nov 20 15:50 ..
drwxr-xr-x 3 root root    0 Nov 20 15:47 controlC2
lrwxrwxrwx 1 root root    0 Nov 20 15:47 device -> ../../../acp-pdm-mach
-rw-r--r-- 1 root root 4096 Nov 20 15:50 id
-r--r--r-- 1 root root 4096 Nov 20 15:47 number
drwxr-xr-x 3 root root    0 Nov 20 15:47 pcmC2D0c
drwxr-xr-x 2 root root    0 Nov 20 15:50 power
lrwxrwxrwx 1 root root    0 Nov 20 15:47 subsystem -> ../../../../../../../../class/sound
-rw-r--r-- 1 root root 4096 Nov 20 15:47 uevent

# ls -la /sys/class/sound/controlC2/device/device/
total 0
drwxr-xr-x 5 root root    0 Nov 20 15:50 .
drwxr-xr-x 4 root root    0 Nov 20 15:50 ..
drwxr-xr-x 3 root root    0 Nov 20 15:50 acp-dmic-codec
lrwxrwxrwx 1 root root    0 Nov 20 15:47 driver -> ../../../../../../bus/platform/drivers/acp_mach
-rw-r--r-- 1 root root 4096 Nov 20 15:50 driver_override
-r--r--r-- 1 root root 4096 Nov 20 15:50 modalias
drwxr-xr-x 2 root root    0 Nov 20 15:50 power
drwxr-xr-x 3 root root    0 Nov 20 15:50 sound
lrwxrwxrwx 1 root root    0 Nov 20 15:47 subsystem -> ../../../../../../bus/platform
-rw-r--r-- 1 root root 4096 Nov 20 15:50 uevent

After the change of link name acp-dmic-codec,
the micmute led can work on ThinkPad T14s Gen 6.