### PR TITLE
Topology: NHLT: Intel: Fix mono DMIC configure for MTL platform

### DIFF
--- a/topology/nhlt/intel/dmic/dmic-process.c
+++ b/topology/nhlt/intel/dmic/dmic-process.c
@@ -776,7 +776,7 @@ static int configure_registers(struct intel_dmic_params *dmic, struct dmic_calc_
 
 	ret = stereo_helper(dmic, stereo, swap, ipmsm);
 	if (ret < 0) {
-		fprintf(stderr, "%s: enable conflict\n", __func__);
+		fprintf(stderr, "%s: Microphones enable conflict for DMIC0 and DMIC1 FIFOs\n", __func__);
 		return ret;
 	}
 


### PR DESCRIPTION
This change fixes the blob generator for mono microphone configuration. As difference to previous platforms the FIFO packer mono/stereo mode set up in OUTCONTROLx IPM_SOURCE_MODE bit-field.