### PR TITLE
Topology: NHLT: Intel: Fix DMA slots config in SSP blob

### DIFF
--- a/topology/nhlt/intel/ssp/ssp-process.c
+++ b/topology/nhlt/intel/ssp/ssp-process.c
@@ -60,11 +60,11 @@ static void ssp_calculate_intern_v30(struct intel_nhlt_params *nhlt, int hwi)
 	blob30->rsvd2 = 0;
 	blob30->ssioc = blob->ssioc;
 
-	blob30->rx_dir[0].ssmidytsa = 3;
+	blob30->rx_dir[0].ssmidytsa = ssp->ssp_prm[di].hw_cfg[hwi].rx_slots;
 	for (i = 1; i < I2SIPCMC; i++)
 		blob30->rx_dir[i].ssmidytsa = 0;
 
-	blob30->tx_dir[0].ssmodytsa = 3;
+	blob30->tx_dir[0].ssmodytsa = ssp->ssp_prm[di].hw_cfg[hwi].tx_slots;
 	for (i = 1; i < I2SOPCMC; i++)
 		blob30->tx_dir[i].ssmodytsa = 0;
 


### PR DESCRIPTION
This fixes a mistake in function ssp_calculate_intern_v30(). The rx_dir[0] and tx_dir[0] value was hard-coded to 0x3 for typical stereo slots configuration. It should be instead retrieved from topology parameters for the SSP.