### PR TITLE
aplay: add support for G.711 A_LAW enconding in AU file format

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -1245,6 +1245,12 @@ static int test_au(int fd, void *buffer)
 			fprintf(stderr, _("Warning: format is changed to S16_BE\n"));
 		hwparams.format = SND_PCM_FORMAT_S16_BE;
 		break;
+	case AU_FMT_ALAW:
+		if (hwparams.format != DEFAULT_FORMAT &&
+		    hwparams.format != SND_PCM_FORMAT_A_LAW)
+			fprintf(stderr, _("Warning: format is changed to A_LAW\n"));
+		hwparams.format = SND_PCM_FORMAT_A_LAW;
+		break;
 	default:
 		return -1;
 	}
@@ -2786,6 +2792,9 @@ static void begin_au(int fd, size_t cnt)
 		break;
 	case SND_PCM_FORMAT_S16_BE:
 		ah.encoding = BE_INT(AU_FMT_LIN16);
+		break;
+	case SND_PCM_FORMAT_A_LAW:
+		ah.encoding = BE_INT(AU_FMT_ALAW);
 		break;
 	default:
 		error(_("Sparc Audio doesn't support %s format..."), snd_pcm_format_name(hwparams.format));

--- a/aplay/formats.h
+++ b/aplay/formats.h
@@ -120,6 +120,7 @@ typedef struct {
 #define AU_FMT_ULAW		1
 #define AU_FMT_LIN8		2
 #define AU_FMT_LIN16		3
+#define AU_FMT_ALAW		27
 
 typedef struct au_header {
 	uint32_t magic;		/* '.snd' */


### PR DESCRIPTION
At the time being, aplay only supports G.711 µ-law, 8-bits PCM and 16-bits PCM encodings for the AU format while the AU format supports many more.

In Europe the most G.711 used encoding is the A-law, which is also part of the encodings supported by the AU file format.

Add support for that encoding in aplay.