### PR TITLE
alsaloop: only log xrun debug messages when verbose

### DIFF
--- a/alsaloop/pcmjob.c
+++ b/alsaloop/pcmjob.c
@@ -647,13 +647,15 @@ static int xrun(struct loopback_handle *lhandle)
 	int err;
 
 	if (lhandle == lhandle->loopback->play) {
-		logit(LOG_DEBUG, "underrun for %s\n", lhandle->id);
+		if (verbose)
+			logit(LOG_DEBUG, "underrun for %s\n", lhandle->id);
 		xrun_stats(lhandle->loopback);
 		if ((err = snd_pcm_prepare(lhandle->handle)) < 0)
 			return err;
 		lhandle->xrun_pending = 1;
 	} else {
-		logit(LOG_DEBUG, "overrun for %s\n", lhandle->id);
+		if (verbose)
+			logit(LOG_DEBUG, "overrun for %s\n", lhandle->id);
 		xrun_stats(lhandle->loopback);
 		if ((err = snd_pcm_prepare(lhandle->handle)) < 0)
 			return err;


### PR DESCRIPTION
Xruns can happen quite often (E.G. continuously when using alsaloop to/from the UAC gadget driver without a connected host), so only log the debug messages when verbose logging has been requested to not flood the logs.