### PR TITLE
amixer: always use line buffering for (s)events

### DIFF
--- a/amixer/amixer.c
+++ b/amixer/amixer.c
@@ -1595,6 +1595,8 @@ static int events(int argc ATTRIBUTE_UNUSED, char *argv[] ATTRIBUTE_UNUSED)
 	snd_hctl_elem_t *helem;
 	int err;
 
+	setlinebuf(stdout);
+
 	if ((err = snd_hctl_open(&handle, card, 0)) < 0) {
 		error("Control %s open error: %s\n", card, snd_strerror(err));
 		return err;
@@ -1673,6 +1675,8 @@ static int sevents(int argc ATTRIBUTE_UNUSED, char *argv[] ATTRIBUTE_UNUSED)
 {
 	snd_mixer_t *handle;
 	int err;
+
+	setlinebuf(stdout);
 
 	if ((err = snd_mixer_open(&handle, 0)) < 0) {
 		error("Mixer %s open error: %s", card, snd_strerror(err));

--- a/bat/alsa.c
+++ b/bat/alsa.c
@@ -221,23 +221,23 @@ static int set_snd_pcm_params(struct bat *bat, struct pcm_container *sndpcm)
 
 		period_time = buffer_time / DIV_BUFFERTIME;
 
-		/* Set buffer time and period time */
+		/* Set period time and buffer time */
+		err = snd_pcm_hw_params_set_period_time_near(sndpcm->handle,
+			params, &period_time, 0);
+		if (err < 0) {
+			fprintf(bat->err, _("Set parameter to device error: "));
+			fprintf(bat->err, _("period time: %d %s: %s(%d)\n"),
+					period_time,
+					device_name, snd_strerror(err), err);
+			return err;
+		}
+
 		err = snd_pcm_hw_params_set_buffer_time_near(sndpcm->handle,
 				params, &buffer_time, 0);
 		if (err < 0) {
 			fprintf(bat->err, _("Set parameter to device error: "));
 			fprintf(bat->err, _("buffer time: %d %s: %s(%d)\n"),
 					buffer_time,
-					device_name, snd_strerror(err), err);
-			return err;
-		}
-
-		err = snd_pcm_hw_params_set_period_time_near(sndpcm->handle,
-				params, &period_time, 0);
-		if (err < 0) {
-			fprintf(bat->err, _("Set parameter to device error: "));
-			fprintf(bat->err, _("period time: %d %s: %s(%d)\n"),
-					period_time,
 					device_name, snd_strerror(err), err);
 			return err;
 		}


### PR DESCRIPTION
Line buffering is the obviously correct mode for (s)events, but block
buffering would typically be used when piping its output to another
program.
