### PR TITLE
configure: Allow systemd service installation without systemd.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,8 +419,8 @@ AC_ARG_WITH([systemdsystemunitdir],
 if test "x$with_systemdsystemunitdir" != xno; then
         AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
-AM_CONDITIONAL(HAVE_SYSTEMD, [test "$have_min_systemd" = "yes" \
-        -a -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" \
+			      -a "x$with_systemdsystemunitdir" != xno ])
 
 AC_ARG_WITH([asound-state-dir],
         AS_HELP_STRING([--with-asound-state-dir=DIR], [Directory to place asound.state file in]),


### PR DESCRIPTION
If the systemdsystemunitdir got passed anyway as a variable, we don't need the systemd.pc dependency anymore and allow building without a systemd build-dependency.

Relevant in Alpine Linux, where we allowed systemd services to be (sub-)packaged (e.g. for downstreams like postmarketOS), but don't have systemd pacakged in Alpine itself, yet.