### PR TITLE
aplay: add missing break before the default case

### DIFF
--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -2731,6 +2731,7 @@ static void begin_wave(int fd, size_t cnt)
 	case SND_PCM_FORMAT_S32_LE:
 	case SND_PCM_FORMAT_FLOAT_LE:
 	case SND_PCM_FORMAT_S24_3LE:
+		break;
 	default:
 _format:
 		error(_("Wave doesn't support %s format..."), snd_pcm_format_name(hwparams.format));


### PR DESCRIPTION
Add the break before the default case back. Otherwise, all cases will fall into the default/error case.

Fixes: e78583ab7cde ("aplay: reorganize format handling in begin_wave()")