### PR TITLE
speaker-test: fix segfault with more than 16 channels

### DIFF
--- a/speaker-test/speaker-test.c
+++ b/speaker-test/speaker-test.c
@@ -285,7 +285,9 @@ static const char *get_channel_name(int chn)
     return name ? name : "Unknown";
   }
 #endif
-  return gettext(channel_name[chn]);
+  if (chn < MAX_CHANNELS)
+    return gettext(channel_name[chn]);
+  return "Unknown";
 }
 
 static const int	supported_formats[] = {


### PR DESCRIPTION
get_channel_name() accessed the channel_name array without bounds checking. When using more than 16 channels without a channel map, it would read past the end of the array and crash.

Tested with 26 channels on Scarlett 4th Gen 18i20.