### PR TITLE
amixer: support infinite line length for --stdin option and add --file option

### DIFF
--- a/amixer/amixer.c
+++ b/amixer/amixer.c
@@ -71,6 +71,7 @@ static int help(void)
 	printf("  -i,--inactive   show also inactive controls\n");
 	printf("  -a,--abstract L select abstraction level (none or basic)\n");
 	printf("  -s,--stdin      Read and execute commands from stdin sequentially\n");
+	printf("  -f,--file FILE  Read and execute commands from file sequentially\n");
 	printf("  -R,--raw-volume Use the raw value (default)\n");
 	printf("  -M,--mapped-volume Use the mapped volume\n");
 	printf("\nAvailable commands:\n");
@@ -1757,7 +1758,7 @@ static int split_line(char *buf, char **token, int max_token)
 
 #define MAX_ARGS	32
 
-static int exec_stdin(void)
+static int exec_file(FILE *file)
 {
 	int narg;
 	char *buf = NULL, *args[MAX_ARGS];
@@ -1767,7 +1768,7 @@ static int exec_stdin(void)
 	/* quiet = 1; */
 	ignore_error = 1;
 
-	while (getline(&buf, &size, stdin) > 0) {
+	while (getline(&buf, &size, file) > 0) {
 		narg = split_line(buf, args, MAX_ARGS);
 		if (narg > 0) {
 			if (!strcmp(args[0], "sset") || !strcmp(args[0], "set"))
@@ -1788,6 +1789,8 @@ int main(int argc, char *argv[])
 {
 	int badopt, retval, level = 0;
 	int read_stdin = 0;
+	int read_file = 0;
+	char filename[256] = { 0 };
 	static const struct option long_option[] =
 	{
 		{"help", 0, NULL, 'h'},
@@ -1800,6 +1803,7 @@ int main(int argc, char *argv[])
 		{"version", 0, NULL, 'v'},
 		{"abstract", 1, NULL, 'a'},
 		{"stdin", 0, NULL, 's'},
+		{"file", 1, NULL, 'f'},
 		{"raw-volume", 0, NULL, 'R'},
 		{"mapped-volume", 0, NULL, 'M'},
 		{NULL, 0, NULL, 0},
@@ -1809,7 +1813,7 @@ int main(int argc, char *argv[])
 	while (1) {
 		int c;
 
-		if ((c = getopt_long(argc, argv, "hc:D:qidnva:sRM", long_option, NULL)) < 0)
+		if ((c = getopt_long(argc, argv, "hc:D:qidnva:sf:RM", long_option, NULL)) < 0)
 			break;
 		switch (c) {
 		case 'h':
@@ -1866,6 +1870,11 @@ int main(int argc, char *argv[])
 		case 's':
 			read_stdin = 1;
 			break;
+		case 'f':
+			read_file = 1;
+			strncpy(filename, optarg, sizeof(filename)-1);
+			filename[sizeof(filename)-1] = '\0';
+			break;
 		case 'R':
 			std_vol_type = VOL_RAW;
 			break;
@@ -1883,7 +1892,21 @@ int main(int argc, char *argv[])
 	smixer_options.device = card;
 
 	if (read_stdin) {
-		retval = exec_stdin();
+		retval = exec_file(stdin);
+		goto finish;
+	}
+
+	if (read_file) {
+		FILE *file;
+		file = fopen(filename, "r");
+		if (!file) {
+			retval = errno;
+			perror("fopen");
+			goto finish;
+		}
+
+		retval = exec_file(file);
+		fclose(file);
 		goto finish;
 	}
 

--- a/amixer/amixer.c
+++ b/amixer/amixer.c
@@ -1760,13 +1760,14 @@ static int split_line(char *buf, char **token, int max_token)
 static int exec_stdin(void)
 {
 	int narg;
-	char buf[256], *args[MAX_ARGS];
+	char *buf = NULL, *args[MAX_ARGS];
+	size_t size = 0;
 	int err = 0;
 
 	/* quiet = 1; */
 	ignore_error = 1;
 
-	while (fgets(buf, sizeof(buf), stdin)) {
+	while (getline(&buf, &size, stdin) > 0) {
 		narg = split_line(buf, args, MAX_ARGS);
 		if (narg > 0) {
 			if (!strcmp(args[0], "sset") || !strcmp(args[0], "set"))
@@ -1774,10 +1775,12 @@ static int exec_stdin(void)
 			else if (!strcmp(args[0], "cset"))
 				err = cset(narg - 1, args + 1, 0, 1);
 			if (err < 0)
-				return 1;
+				break;
 		}
 	}
-	return 0;
+
+	free(buf);
+	return err < 0 ? 1 : 0;
 }
 
 


### PR DESCRIPTION
There is a problem with limited buffer size for option --stdin 256 bytes. It can be eliminated by making use of getline() function. Furthermore, it's possible to refactor exec_stdin() function to support reading from any file and support --file option. Would be very convenient for any devices with complex audio architecture to speedup boot-up initialization.