### PR TITLE
fix discards const from pointer target 

### DIFF
--- a/alsactl/init_parse.c
+++ b/alsactl/init_parse.c
@@ -692,7 +692,7 @@ dbvalue:
 		int err, index = 0;
 		snd_hctl_elem_t *elem;
 		snd_ctl_elem_id_t *id;
-		char *pos = strchr(attr, ' ');
+		const char *pos = strchr(attr, ' ');
 		if (pos)
 			index = strtol(pos, NULL, 0);
 		err = snd_ctl_elem_id_malloc(&id);
@@ -1281,7 +1281,7 @@ static char *new_root_dir(const char *filename)
 /* return non-zero if the file name has the extension ".conf" */
 static int conf_name_filter(const struct dirent *d)
 {
-	char *ext = strrchr(d->d_name, '.');
+	const char *ext = strrchr(d->d_name, '.');
 	return ext && !strcmp(ext, ".conf");
 }
 

--- a/aplay/aplay.c
+++ b/aplay/aplay.c
@@ -3209,7 +3209,7 @@ static int new_capture_file(char *name, char *namebuf, size_t namelen,
  */
 int create_path(const char *path)
 {
-	char *start;
+	const char *start;
 	mode_t mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
 
 	if (path[0] == '/')

--- a/topology/pre-process-dapm.c
+++ b/topology/pre-process-dapm.c
@@ -168,7 +168,8 @@ static int tplg_pp_get_widget_name(struct tplg_pre_processor *tplg_pp,
 {
 	snd_config_iterator_t i, next;
 	snd_config_t *temp_cfg, *child, *class_cfg, *n;
-	char *class_name, *args, *widget_name;
+	const char *args;
+	char *class_name, *widget_name;
 	int ret;
 
 	/* get class name */
@@ -221,8 +222,8 @@ static int tplg_pp_get_widget_name(struct tplg_pre_processor *tplg_pp,
 
 	/* construct widget name using the constructor argument values */
 	snd_config_for_each(i, next, temp_cfg) {
-		const char *id;
-		char *arg, *remaining, *temp;
+		const char *id, *remaining;
+		char *arg, *temp;
 
 		n = snd_config_iterator_entry(i);
 		if (snd_config_get_string(n, &id) < 0)

--- a/topology/pre-process-object.c
+++ b/topology/pre-process-object.c
@@ -542,8 +542,8 @@ static int tplg_pp_add_object_tuple_section(struct tplg_pre_processor *tplg_pp,
 					    const char *token_ref, const char *array_name)
 {
 	snd_config_t *top, *tuple_cfg, *child, *cfg, *new;
-	const char *id;
-	char *token, *type, *str;
+	const char *id, *type;
+	char *token, *str;
 	long tuple_value;
 	int ret;
 


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

```c

../../alsactl/init_parse.c: In function 'elemid_get':
../../alsactl/init_parse.c:695:29: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  695 |                 char *pos = strchr(attr, ' ');
      |                             ^~~~~~
../../alsactl/init_parse.c: In function 'conf_name_filter':
../../alsactl/init_parse.c:1284:21: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1284 |         char *ext = strrchr(d->d_name, '.');
      |                     ^~~~~~~
../../aplay/aplay.c: In function 'create_path':
../../aplay/aplay.c:3226:23: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3226 |                 start = strchr(path + 1, '/');
      |                       ^
../../aplay/aplay.c:3228:23: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3228 |                 start = strchr(path, '/');
      |                       ^
../../topology/pre-process-object.c: In function 'tplg_pp_add_object_tuple_section':
../../topology/pre-process-object.c:562:14: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  562 |         type = strchr(token_ref, '.');
      |              ^
../../topology/pre-process-dapm.c:175:14: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  175 |         args = strchr(string, '.');
      |              ^

``` 