### PR TITLE
alsactl: use [Install] instead of .wants/ symlinks for systemd integration

### DIFF
--- a/alsactl/Makefile.am
+++ b/alsactl/Makefile.am
@@ -34,14 +34,6 @@ systemdsystemunit_DATA = \
 	conf/alsa-restore.service \
 	conf/alsa-card-wait@.service
 
-install-data-hook:
-	$(MKDIR_P) -m 0755 \
-		$(DESTDIR)$(systemdsystemunitdir)/sound.target.wants
-	( cd $(DESTDIR)$(systemdsystemunitdir)/sound.target.wants && \
-		rm -f alsa-state.service alsa-restore.service && \
-		$(LN_S) ../alsa-state.service alsa-state.service && \
-		$(LN_S) ../alsa-restore.service alsa-restore.service)
-
 endif
 
 edit = \

--- a/alsactl/conf/alsa-restore.service.in
+++ b/alsactl/conf/alsa-restore.service.in
@@ -13,3 +13,6 @@ Type=oneshot
 RemainAfterExit=true
 ExecStart=-@sbindir@/alsactl restore
 ExecStop=-@sbindir@/alsactl store
+
+[Install]
+WantedBy=sound.target

--- a/alsactl/conf/alsa-state.service.in
+++ b/alsactl/conf/alsa-state.service.in
@@ -11,3 +11,6 @@ ConditionPathExists=@daemonswitch@
 Type=simple
 ExecStart=-@sbindir@/alsactl -s -n 19 -c rdaemon
 ExecStop=-@sbindir@/alsactl -s kill save_and_quit
+
+[Install]
+WantedBy=sound.target


### PR DESCRIPTION
This adds [Install] sections with WantedBy=sound.target to alsa-restore and alsa-state service files, and removes the install-data-hook that manually creates .wants/ symlinks. This lets distributions manage enabling/disabling via a preset policy rather than hardwiring it at install time.